### PR TITLE
Fix to Issue #4 and more

### DIFF
--- a/GameBrowser/Configuration/configPage.html
+++ b/GameBrowser/Configuration/configPage.html
@@ -162,6 +162,8 @@
                                 <option value="Xbox 360">Microsoft XBox 360</option>\
                                 <option value="Xbox One">Microsoft XBox One</option>\
                                 <option value="Neo Geo">Neo-Geo</option>\
+                                <option value="Neo Geo Pocket">Neo-Geo Pocket</option>\
+                                <option value="Neo Geo Pocket Color">Neo-Geo Pocket Color</option>\
                                 <option value="Nintendo 64">Nintendo 64</option>\
                                 <option value="Nintendo DS">Nintendo DS</option>\
                                 <option value="Game Boy">Nintendo Game Boy</option>\

--- a/GameBrowser/Configuration/configPage.html
+++ b/GameBrowser/Configuration/configPage.html
@@ -152,6 +152,7 @@
                                 <option value="Atari Jaguar">Atari Jaguar</option>\
                                 <option value="Atari Jaguar CD">Atari Jaguar CD</option>\
                                 <option value="Atari Lynx">Atari Lynx</option>\
+                                <option value="Atari ST">Atari ST</option>\
                                 <option value="Atari XE">Atari XE</option>\
                                 <option value="Colecovision">Colecovision</option>\
                                 <option value="Commodore 64">Commodore 64</option>\

--- a/GameBrowser/Configuration/configPage.html
+++ b/GameBrowser/Configuration/configPage.html
@@ -151,6 +151,7 @@
                                 <option value="Atari 7800">Atari 7800</option>\
                                 <option value="Atari Jaguar">Atari Jaguar</option>\
                                 <option value="Atari Jaguar CD">Atari Jaguar CD</option>\
+                                <option value="Atari Lynx">Atari Lynx</option>\
                                 <option value="Atari XE">Atari XE</option>\
                                 <option value="Colecovision">Colecovision</option>\
                                 <option value="Commodore 64">Commodore 64</option>\

--- a/GameBrowser/Configuration/configPage.html
+++ b/GameBrowser/Configuration/configPage.html
@@ -143,6 +143,12 @@
 
                         html += '<div class="selectContainer">';
                         html += '<select class="selectGameSystem" is="emby-select" label="Game system:">';
+
+                        // TODO Find a way to get acces to GameSystemDefinition.All to fill this list.
+                        // for (var i = 0; i < config.GameSystemDefinitions.length; i++) {
+                        //     var definition = config.GameSystemDefinition[i];
+                        //     html += '<option value="' + definition.Name + '">' + definition.ConsoleType + '</option>';
+                        // }
                         html += '<option value="3DO">3DO</option>\
                                 <option value="Amiga">Amiga</option>\
                                 <option value="Arcade">Arcade</option>\

--- a/GameBrowser/GameBrowser.csproj
+++ b/GameBrowser/GameBrowser.csproj
@@ -20,4 +20,8 @@
     <PackageReference Include="mediabrowser.server.core" Version="3.3.20" />
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="copy /y &quot;$(targetdir)&quot; &quot;%APPDATA%\Emby-Server\plugins&quot;&#xD;&#xA;" />
+  </Target>
+
 </Project>

--- a/GameBrowser/Properties/launchSettings.json
+++ b/GameBrowser/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "GameBrowser": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Users\\cwarr\\AppData\\Roaming\\Emby-Server\\system\\EmbyServer.exe"
+    }
+  }
+}

--- a/GameBrowser/Properties/launchSettings.json
+++ b/GameBrowser/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "GameBrowser": {
       "commandName": "Executable",
-      "executablePath": "C:\\Users\\cwarr\\AppData\\Roaming\\Emby-Server\\system\\EmbyServer.exe"
+      "executablePath": "%APPDATA%\\Emby-Server\\system\\EmbyServer.exe"
     }
   }
 }

--- a/GameBrowser/Providers/CustomGameProvider.cs
+++ b/GameBrowser/Providers/CustomGameProvider.cs
@@ -32,7 +32,7 @@ namespace GameBrowser.Providers
 
                 if (!string.IsNullOrEmpty(platform))
                 {
-                    item.GameSystem = ResolverHelper.GetExtendedInfoFromConsoleType(platform)?.Name;
+                    item.GameSystem = ResolverHelper.GetExtendedInfoFromPlatform(platform)?.Name;
 
                     result = _cachedResultWithUpdate;
                 }

--- a/GameBrowser/Providers/CustomGameProvider.cs
+++ b/GameBrowser/Providers/CustomGameProvider.cs
@@ -32,7 +32,8 @@ namespace GameBrowser.Providers
 
                 if (!string.IsNullOrEmpty(platform))
                 {
-                    item.GameSystem = ResolverHelper.GetGameSystemFromPlatform(platform);
+                    item.GameSystem = ResolverHelper.GetExtendedInfoFromConsoleType(platform)?.Name;
+
                     result = _cachedResultWithUpdate;
                 }
             }

--- a/GameBrowser/Providers/EmuMovies/EmuMoviesImageProvider.cs
+++ b/GameBrowser/Providers/EmuMovies/EmuMoviesImageProvider.cs
@@ -1,14 +1,15 @@
-﻿using MediaBrowser.Common.Net;
+﻿using GameBrowser.Resolvers;
+using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
-using System.Net;
 
 namespace GameBrowser.Providers.EmuMovies
 {
@@ -94,8 +95,7 @@ namespace GameBrowser.Providers.EmuMovies
 
             if (sessionId == null) return list;
 
-            var emuMoviesPlatform = GetEmuMoviesPlatformFromGameSystem(game.GameSystem);
-            // TODO Add a setting to search or not image from other game system
+            var emuMoviesPlatform = ResolverHelper.GetExtendedInfoFromGameSystem(game.GameSystem)?.EmuMoviesPlatform;
             if (string.IsNullOrEmpty(emuMoviesPlatform)) return list;
             var url = string.Format(EmuMoviesUrls.Search, WebUtility.UrlEncode(game.Name), emuMoviesPlatform, mediaType, sessionId);
 
@@ -143,245 +143,6 @@ namespace GameBrowser.Providers.EmuMovies
             }
 
             return list;
-        }
-
-        private string GetEmuMoviesPlatformFromGameSystem(string gameSystem)
-        {
-            string emuMoviesPlatform = null;
-
-            switch (gameSystem)
-            {
-                case "Panasonic3DO":
-                    emuMoviesPlatform = "Panasonic_3DO";
-
-                    break;
-
-                case "Amiga":
-                    emuMoviesPlatform = "";
-
-                    break;
-
-                case "Arcade":
-                    emuMoviesPlatform = "MAME";
-
-                    break;
-
-                case "Atari2600":
-                    emuMoviesPlatform = "Atari_2600";
-
-                    break;
-
-                case "Atari5200":
-                    emuMoviesPlatform = "Atari_5200";
-
-                    break;
-
-                case "Atari7800":
-                    emuMoviesPlatform = "Atari_7800";
-
-                    break;
-
-                case "AtariST":
-                    emuMoviesPlatform = "";
-
-                    break;
-
-                case "AtariXE":
-                    emuMoviesPlatform = "Atari_8_bit";
-
-                    break;
-
-                case "AtariJaguar":
-                    emuMoviesPlatform = "Atari_Jaguar";
-
-                    break;
-
-                case "AtariJaguarCD":
-                    emuMoviesPlatform = "Atari_Jaguar";
-
-                    break;
-
-                case "AtariLynx":
-                    emuMoviesPlatform = "";
-
-                    break;
-
-                case "Colecovision":
-                    emuMoviesPlatform = "Coleco_Vision";
-
-                    break;
-
-                case "Commodore64":
-                    emuMoviesPlatform = "Commodore_64";
-
-                    break;
-
-                case "CommodoreVic20":
-                    emuMoviesPlatform = "";
-
-                    break;
-
-                case "Intellivision":
-                    emuMoviesPlatform = "Mattel_Intellivision";
-
-                    break;
-
-                case "MicrosoftXBox":
-                    emuMoviesPlatform = "Microsoft_Xbox";
-
-                    break;
-
-                case "NeoGeo":
-                    emuMoviesPlatform = "SNK_Neo_Geo_AES";
-
-                    break;
-
-                case "NeoGeoPocket":
-                    emuMoviesPlatform = "";
-
-                    break;
-
-                case "NeoGeoPocketColor":
-                    emuMoviesPlatform = "";
-
-                    break;
-
-                case "Nintendo64":
-                    emuMoviesPlatform = "Nintendo_N64";
-
-                    break;
-
-                case "NintendoDS":
-                    emuMoviesPlatform = "Nintendo_DS";
-
-                    break;
-
-                case "Nintendo":
-                    emuMoviesPlatform = "Nintendo_NES";
-
-                    break;
-
-                case "NintendoGameBoy":
-                    emuMoviesPlatform = "Nintendo_Game_Boy";
-
-                    break;
-
-                case "NintendoGameBoyAdvance":
-                    emuMoviesPlatform = "Nintendo_Game_Boy_Advance";
-
-                    break;
-
-                case "NintendoGameBoyColor":
-                    emuMoviesPlatform = "Nintendo_Game_Boy_Color";
-
-                    break;
-
-                case "NintendoGameCube":
-                    emuMoviesPlatform = "Nintendo_GameCube";
-
-                    break;
-
-                case "SuperNintendo":
-                    emuMoviesPlatform = "Nintendo_SNES";
-
-                    break;
-
-                case "VirtualBoy":
-                    emuMoviesPlatform = "";
-
-                    break;
-
-                case "Wii":
-                    emuMoviesPlatform = "";
-
-                    break;
-
-                case "DOS":
-                    emuMoviesPlatform = "";
-
-                    break;
-
-                case "Windows":
-                    emuMoviesPlatform = "";
-
-                    break;
-
-                case "Sega32X":
-                    emuMoviesPlatform = "Sega_Genesis";
-
-                    break;
-
-                case "SegaCD":
-                    emuMoviesPlatform = "Sega_Genesis";
-
-                    break;
-
-                case "SegaDreamcast":
-                    emuMoviesPlatform = "Sega_Dreamcast";
-
-                    break;
-
-                case "SegaGameGear":
-                    emuMoviesPlatform = "Sega_Game_Gear";
-
-                    break;
-
-                case "SegaGenesis":
-                    emuMoviesPlatform = "Sega_Genesis";
-
-                    break;
-
-                case "SegaMasterSystem":
-                    emuMoviesPlatform = "Sega_Master_System";
-
-                    break;
-
-                case "SegaMegaDrive":
-                    emuMoviesPlatform = "Sega_Genesis";
-
-                    break;
-
-                case "SegaSaturn":
-                    emuMoviesPlatform = "Sega_Saturn";
-
-                    break;
-
-                case "SonyPlaystation":
-                    emuMoviesPlatform = "Sony_Playstation";
-
-                    break;
-
-                case "SonyPlaystation2":
-                    emuMoviesPlatform = "Sony_Playstation_2";
-
-                    break;
-
-                case "SonyPSP":
-                    emuMoviesPlatform = "Sony_PSP";
-
-                    break;
-
-                case "TurboGrafx16":
-                    emuMoviesPlatform = "NEC_TurboGrafx_16";
-
-                    break;
-
-                case "TurboGrafxCD":
-                    emuMoviesPlatform = "NEC_TurboGrafx_16";
-                    break;
-
-                case "ZxSpectrum":
-                    emuMoviesPlatform = "";
-                    break;
-
-#if DEBUG
-                default:
-                    throw new ArgumentException($"Unrecognized game system: {gameSystem}.");
-#endif
-            }
-
-            return emuMoviesPlatform;
-
         }
 
         public IEnumerable<ImageType> GetSupportedImages(BaseItem item)

--- a/GameBrowser/Providers/EmuMovies/EmuMoviesImageProvider.cs
+++ b/GameBrowser/Providers/EmuMovies/EmuMoviesImageProvider.cs
@@ -94,7 +94,10 @@ namespace GameBrowser.Providers.EmuMovies
 
             if (sessionId == null) return list;
 
-            var url = string.Format(EmuMoviesUrls.Search, WebUtility.UrlEncode(game.Name), GetEmuMoviesPlatformFromGameSystem(game.GameSystem), mediaType, sessionId);
+            var emuMoviesPlatform = GetEmuMoviesPlatformFromGameSystem(game.GameSystem);
+            // TODO Add a setting to search or not image from other game system
+            if (string.IsNullOrEmpty(emuMoviesPlatform)) return list;
+            var url = string.Format(EmuMoviesUrls.Search, WebUtility.UrlEncode(game.Name), emuMoviesPlatform, mediaType, sessionId);
 
             using (var response = await _httpClient.SendAsync(new HttpRequestOptions
             {

--- a/GameBrowser/Providers/EmuMovies/EmuMoviesImageProvider.cs
+++ b/GameBrowser/Providers/EmuMovies/EmuMoviesImageProvider.cs
@@ -231,6 +231,16 @@ namespace GameBrowser.Providers.EmuMovies
 
                     break;
 
+                case "NeoGeoPocket":
+                    emuMoviesPlatform = "";
+
+                    break;
+
+                case "NeoGeoPocketColor":
+                    emuMoviesPlatform = "";
+
+                    break;
+
                 case "Nintendo64":
                     emuMoviesPlatform = "Nintendo_N64";
 

--- a/GameBrowser/Providers/EmuMovies/EmuMoviesImageProvider.cs
+++ b/GameBrowser/Providers/EmuMovies/EmuMoviesImageProvider.cs
@@ -58,7 +58,6 @@ namespace GameBrowser.Providers.EmuMovies
                 case ImageType.Banner:
                     return FetchImages(game, EmuMoviesMediaTypes.Banner, imageType, cancellationToken);
                 case ImageType.Primary:
-                case ImageType.Box:
                     return FetchImages(game, EmuMoviesMediaTypes.Box, imageType, cancellationToken);
                 case ImageType.BoxRear:
                     return FetchImages(game, EmuMoviesMediaTypes.BoxBack, imageType, cancellationToken);
@@ -70,6 +69,7 @@ namespace GameBrowser.Providers.EmuMovies
                     return FetchImages(game, EmuMoviesMediaTypes.Snap, imageType, cancellationToken);
 
                 case ImageType.Art:
+                case ImageType.Box:
                 case ImageType.Logo:
                 case ImageType.Thumb:
                 case ImageType.Chapter:
@@ -371,7 +371,7 @@ namespace GameBrowser.Providers.EmuMovies
 
         public IEnumerable<ImageType> GetSupportedImages(BaseItem item)
         {
-            return new[] { ImageType.Primary, ImageType.Backdrop, ImageType.Banner, ImageType.Box, ImageType.BoxRear, ImageType.Disc, ImageType.Menu, ImageType.Screenshot };
+            return new[] { ImageType.Primary, ImageType.Backdrop, ImageType.Banner, ImageType.BoxRear, ImageType.Disc, ImageType.Menu, ImageType.Screenshot };
         }
 
         public string Name

--- a/GameBrowser/Providers/EmuMovies/EmuMoviesImageProvider.cs
+++ b/GameBrowser/Providers/EmuMovies/EmuMoviesImageProvider.cs
@@ -193,6 +193,11 @@ namespace GameBrowser.Providers.EmuMovies
 
                     break;
 
+                case "AtariLynx":
+                    emuMoviesPlatform = "";
+
+                    break;
+
                 case "Colecovision":
                     emuMoviesPlatform = "Coleco_Vision";
 

--- a/GameBrowser/Providers/EmuMovies/EmuMoviesImageProvider.cs
+++ b/GameBrowser/Providers/EmuMovies/EmuMoviesImageProvider.cs
@@ -53,14 +53,26 @@ namespace GameBrowser.Providers.EmuMovies
 
             switch (imageType)
             {
-                case ImageType.Box:
+                case ImageType.Backdrop:
                     return FetchImages(game, EmuMoviesMediaTypes.Cabinet, imageType, cancellationToken);
-                case ImageType.Screenshot:
-                    return FetchImages(game, EmuMoviesMediaTypes.Snap, imageType, cancellationToken);
+                case ImageType.Banner:
+                    return FetchImages(game, EmuMoviesMediaTypes.Banner, imageType, cancellationToken);
+                case ImageType.Primary:
+                case ImageType.Box:
+                    return FetchImages(game, EmuMoviesMediaTypes.Box, imageType, cancellationToken);
+                case ImageType.BoxRear:
+                    return FetchImages(game, EmuMoviesMediaTypes.BoxBack, imageType, cancellationToken);
                 case ImageType.Disc:
                     return FetchImages(game, EmuMoviesMediaTypes.Cart, imageType, cancellationToken);
                 case ImageType.Menu:
                     return FetchImages(game, EmuMoviesMediaTypes.Title, imageType, cancellationToken);
+                case ImageType.Screenshot:
+                    return FetchImages(game, EmuMoviesMediaTypes.Snap, imageType, cancellationToken);
+
+                case ImageType.Art:
+                case ImageType.Logo:
+                case ImageType.Thumb:
+                case ImageType.Chapter:
                 default:
                     throw new ArgumentException("Unrecognized image type");
             }
@@ -351,7 +363,7 @@ namespace GameBrowser.Providers.EmuMovies
 
         public IEnumerable<ImageType> GetSupportedImages(BaseItem item)
         {
-            return new[] { ImageType.Box, ImageType.Disc, ImageType.Screenshot, ImageType.Menu };
+            return new[] { ImageType.Primary, ImageType.Backdrop, ImageType.Banner, ImageType.Box, ImageType.BoxRear, ImageType.Disc, ImageType.Menu, ImageType.Screenshot };
         }
 
         public string Name

--- a/GameBrowser/Providers/EmuMovies/EmuMoviesImageProvider.cs
+++ b/GameBrowser/Providers/EmuMovies/EmuMoviesImageProvider.cs
@@ -130,13 +130,13 @@ namespace GameBrowser.Providers.EmuMovies
             return list;
         }
 
-        private string GetEmuMoviesPlatformFromGameSystem(string platform)
+        private string GetEmuMoviesPlatformFromGameSystem(string gameSystem)
         {
             string emuMoviesPlatform = null;
 
-            switch (platform)
+            switch (gameSystem)
             {
-                case "3DO":
+                case "Panasonic3DO":
                     emuMoviesPlatform = "Panasonic_3DO";
 
                     break;
@@ -151,32 +151,32 @@ namespace GameBrowser.Providers.EmuMovies
 
                     break;
 
-                case "Atari 2600":
+                case "Atari2600":
                     emuMoviesPlatform = "Atari_2600";
 
                     break;
 
-                case "Atari 5200":
+                case "Atari5200":
                     emuMoviesPlatform = "Atari_5200";
 
                     break;
 
-                case "Atari 7800":
+                case "Atari7800":
                     emuMoviesPlatform = "Atari_7800";
 
                     break;
 
-                case "Atari XE":
+                case "AtariXE":
                     emuMoviesPlatform = "Atari_8_bit";
 
                     break;
 
-                case "Atari Jaguar":
+                case "AtariJaguar":
                     emuMoviesPlatform = "Atari_Jaguar";
 
                     break;
 
-                case "Atari Jaguar CD":
+                case "AtariJaguarCD":
                     emuMoviesPlatform = "Atari_Jaguar";
 
                     break;
@@ -186,12 +186,12 @@ namespace GameBrowser.Providers.EmuMovies
 
                     break;
 
-                case "Commodore 64":
+                case "Commodore64":
                     emuMoviesPlatform = "Commodore_64";
 
                     break;
 
-                case "Commodore Vic-20":
+                case "CommodoreVic20":
                     emuMoviesPlatform = "";
 
                     break;
@@ -201,22 +201,22 @@ namespace GameBrowser.Providers.EmuMovies
 
                     break;
 
-                case "Xbox":
+                case "MicrosoftXBox":
                     emuMoviesPlatform = "Microsoft_Xbox";
 
                     break;
 
-                case "Neo Geo":
+                case "NeoGeo":
                     emuMoviesPlatform = "SNK_Neo_Geo_AES";
 
                     break;
 
-                case "Nintendo 64":
+                case "Nintendo64":
                     emuMoviesPlatform = "Nintendo_N64";
 
                     break;
 
-                case "Nintendo DS":
+                case "NintendoDS":
                     emuMoviesPlatform = "Nintendo_DS";
 
                     break;
@@ -226,37 +226,37 @@ namespace GameBrowser.Providers.EmuMovies
 
                     break;
 
-                case "Game Boy":
+                case "NintendoGameBoy":
                     emuMoviesPlatform = "Nintendo_Game_Boy";
 
                     break;
 
-                case "Game Boy Advance":
+                case "NintendoGameBoyAdvance":
                     emuMoviesPlatform = "Nintendo_Game_Boy_Advance";
 
                     break;
 
-                case "Game Boy Color":
+                case "NintendoGameBoyColor":
                     emuMoviesPlatform = "Nintendo_Game_Boy_Color";
 
                     break;
 
-                case "Gamecube":
+                case "NintendoGameCube":
                     emuMoviesPlatform = "Nintendo_GameCube";
 
                     break;
 
-                case "Super Nintendo":
+                case "SuperNintendo":
                     emuMoviesPlatform = "Nintendo_SNES";
 
                     break;
 
-                case "Virtual Boy":
+                case "VirtualBoy":
                     emuMoviesPlatform = "";
 
                     break;
 
-                case "Nintendo Wii":
+                case "Wii":
                     emuMoviesPlatform = "";
 
                     break;
@@ -271,73 +271,78 @@ namespace GameBrowser.Providers.EmuMovies
 
                     break;
 
-                case "Sega 32X":
+                case "Sega32X":
                     emuMoviesPlatform = "Sega_Genesis";
 
                     break;
 
-                case "Sega CD":
+                case "SegaCD":
                     emuMoviesPlatform = "Sega_Genesis";
 
                     break;
 
-                case "Dreamcast":
+                case "SegaDreamcast":
                     emuMoviesPlatform = "Sega_Dreamcast";
 
                     break;
 
-                case "Game Gear":
+                case "SegaGameGear":
                     emuMoviesPlatform = "Sega_Game_Gear";
 
                     break;
 
-                case "Sega Genesis":
+                case "SegaGenesis":
                     emuMoviesPlatform = "Sega_Genesis";
 
                     break;
 
-                case "Sega Master System":
+                case "SegaMasterSystem":
                     emuMoviesPlatform = "Sega_Master_System";
 
                     break;
 
-                case "Sega Mega Drive":
+                case "SegaMegaDrive":
                     emuMoviesPlatform = "Sega_Genesis";
 
                     break;
 
-                case "Sega Saturn":
+                case "SegaSaturn":
                     emuMoviesPlatform = "Sega_Saturn";
 
                     break;
 
-                case "Sony Playstation":
+                case "SonyPlaystation":
                     emuMoviesPlatform = "Sony_Playstation";
 
                     break;
 
-                case "PS2":
+                case "SonyPlaystation2":
                     emuMoviesPlatform = "Sony_Playstation_2";
 
                     break;
 
-                case "PSP":
+                case "SonyPSP":
                     emuMoviesPlatform = "Sony_PSP";
 
                     break;
 
-                case "TurboGrafx 16":
+                case "TurboGrafx16":
                     emuMoviesPlatform = "NEC_TurboGrafx_16";
 
                     break;
 
-                case "TurboGrafx CD":
+                case "TurboGrafxCD":
                     emuMoviesPlatform = "NEC_TurboGrafx_16";
                     break;
 
-                case "ZX Spectrum":
+                case "ZxSpectrum":
                     emuMoviesPlatform = "";
                     break;
+
+#if DEBUG
+                default:
+                    throw new ArgumentException($"Unrecognized game system: {gameSystem}.");
+#endif
             }
 
             return emuMoviesPlatform;

--- a/GameBrowser/Providers/EmuMovies/EmuMoviesImageProvider.cs
+++ b/GameBrowser/Providers/EmuMovies/EmuMoviesImageProvider.cs
@@ -181,6 +181,11 @@ namespace GameBrowser.Providers.EmuMovies
 
                     break;
 
+                case "AtariST":
+                    emuMoviesPlatform = "";
+
+                    break;
+
                 case "AtariXE":
                     emuMoviesPlatform = "Atari_8_bit";
 

--- a/GameBrowser/Providers/EmuMovies/EmuMoviesMediaTypes.cs
+++ b/GameBrowser/Providers/EmuMovies/EmuMoviesMediaTypes.cs
@@ -2,6 +2,9 @@
 {
     enum EmuMoviesMediaTypes
     {
+        Banner,
+        Box,
+        BoxBack,
         Cabinet,
         Cart,
         Snap,

--- a/GameBrowser/Providers/GamesDb/GamesDbGameProvider.cs
+++ b/GameBrowser/Providers/GamesDb/GamesDbGameProvider.cs
@@ -668,6 +668,11 @@ namespace GameBrowser.Providers.GamesDb
 
                     break;
 
+                case "AtariLynx":
+                    tgdbPlatformString = "Atari Lynx";
+
+                    break;
+
                 case "Colecovision":
                     tgdbPlatformString = "Colecovision";
 

--- a/GameBrowser/Providers/GamesDb/GamesDbGameProvider.cs
+++ b/GameBrowser/Providers/GamesDb/GamesDbGameProvider.cs
@@ -653,6 +653,11 @@ namespace GameBrowser.Providers.GamesDb
 
                     break;
 
+                case "AtariST":
+                    tgdbPlatformString = "Atari ST";
+
+                    break;
+
                 case "AtariXE":
                     tgdbPlatformString = "Atari XE";
 

--- a/GameBrowser/Providers/GamesDb/GamesDbGameProvider.cs
+++ b/GameBrowser/Providers/GamesDb/GamesDbGameProvider.cs
@@ -623,7 +623,7 @@ namespace GameBrowser.Providers.GamesDb
 
             switch (gameSystem)
             {
-                case "3DO":
+                case "Panasonic3DO":
                     tgdbPlatformString = "3DO";
 
                     break;
@@ -638,32 +638,32 @@ namespace GameBrowser.Providers.GamesDb
 
                     break;
 
-                case "Atari 2600":
+                case "Atari2600":
                     tgdbPlatformString = "Atari 2600";
 
                     break;
 
-                case "Atari 5200":
+                case "Atari5200":
                     tgdbPlatformString = "Atari 5200";
 
                     break;
 
-                case "Atari 7800":
+                case "Atari7800":
                     tgdbPlatformString = "Atari 7800";
 
                     break;
 
-                case "Atari XE":
+                case "AtariXE":
                     tgdbPlatformString = "Atari XE";
 
                     break;
 
-                case "Atari Jaguar":
+                case "AtariJaguar":
                     tgdbPlatformString = "Atari Jaguar";
 
                     break;
 
-                case "Atari Jaguar CD":
+                case "AtariJaguarCD":
                     tgdbPlatformString = "Atari Jaguar CD";
 
                     break;
@@ -673,12 +673,12 @@ namespace GameBrowser.Providers.GamesDb
 
                     break;
 
-                case "Commodore 64":
+                case "Commodore64":
                     tgdbPlatformString = "Commodore 64";
 
                     break;
 
-                case "Commodore Vic-20":
+                case "CommodoreVic20":
                     tgdbPlatformString = "Commodore Vic-20";
 
                     break;
@@ -688,32 +688,31 @@ namespace GameBrowser.Providers.GamesDb
 
                     break;
 
-                case "Xbox":
+                case "MicrosoftXBox":
                     tgdbPlatformString = "Microsoft Xbox";
 
                     break;
 
-                case "Xbox 360":
+                case "MicrosoftXBox360":
                     tgdbPlatformString = "Microsoft Xbox 360";
 
                     break;
 
-                case "Xbox One":
+                case "MicrosoftXBoxOne":
                     tgdbPlatformString = "Microsoft Xbox One";
 
                     break;
 
-                case "Neo Geo":
+                case "NeoGeo":
                     tgdbPlatformString = "NeoGeo";
 
                     break;
 
-                case "Nintendo 64":
+                case "Nintendo64":
                     tgdbPlatformString = "Nintendo 64";
-
                     break;
 
-                case "Nintendo DS":
+                case "NintendoDS":
                     tgdbPlatformString = "Nintendo DS";
 
                     break;
@@ -723,42 +722,42 @@ namespace GameBrowser.Providers.GamesDb
 
                     break;
 
-                case "Game Boy":
+                case "NintendoGameBoy":
                     tgdbPlatformString = "Nintendo Game Boy";
 
                     break;
 
-                case "Game Boy Advance":
+                case "NintendoGameBoyAdvance":
                     tgdbPlatformString = "Nintendo Game Boy Advance";
 
                     break;
 
-                case "Game Boy Color":
+                case "NintendoGameBoyColor":
                     tgdbPlatformString = "Nintendo Game Boy Color";
 
                     break;
 
-                case "Gamecube":
+                case "NintendoGameCube":
                     tgdbPlatformString = "Nintendo GameCube";
 
                     break;
 
-                case "Super Nintendo":
+                case "SuperNintendo":
                     tgdbPlatformString = "Super Nintendo (SNES)";
 
                     break;
 
-                case "Virtual Boy":
+                case "VirtualBoy":
                     tgdbPlatformString = "Nintendo Virtual Boy";
 
                     break;
 
-                case "Nintendo Wii":
+                case "Wii":
                     tgdbPlatformString = "Nintendo Wii";
 
                     break;
 
-                case "Nintendo Wii U":
+                case "WiiU":
                     tgdbPlatformString = "Nintendo Wii U";
 
                     break;
@@ -773,83 +772,88 @@ namespace GameBrowser.Providers.GamesDb
 
                     break;
 
-                case "Sega 32X":
+                case "Sega32X":
                     tgdbPlatformString = "Sega 32X";
 
                     break;
 
-                case "Sega CD":
+                case "SegaCD":
                     tgdbPlatformString = "Sega CD";
 
                     break;
 
-                case "Sega Dreamcast":
+                case "SegaDreamcast":
                     tgdbPlatformString = "Sega Dreamcast";
 
                     break;
 
-                case "Game Gear":
+                case "SegaGameGear":
                     tgdbPlatformString = "Sega Game Gear";
 
                     break;
 
-                case "Sega Genesis":
+                case "SegaGenesis":
                     tgdbPlatformString = "Sega Genesis";
 
                     break;
 
-                case "Sega Master System":
+                case "SegaMasterSystem":
                     tgdbPlatformString = "Sega Master System";
 
                     break;
 
-                case "Sega Mega Drive":
+                case "SegaMegaDrive":
                     tgdbPlatformString = "Sega Genesis";
 
                     break;
 
-                case "Sega Saturn":
+                case "SegaSaturn":
                     tgdbPlatformString = "Sega Saturn";
 
                     break;
 
-                case "Sony Playstation":
+                case "SonyPlaystation":
                     tgdbPlatformString = "Sony Playstation";
 
                     break;
 
-                case "PS2":
+                case "SonyPlaystation2":
                     tgdbPlatformString = "Sony Playstation 2";
 
                     break;
 
-                case "PS3":
+                case "SonyPlaystation3":
                     tgdbPlatformString = "Sony Playstation 3";
 
                     break;
 
-                case "PS4":
+                case "SonyPlaystation4":
                     tgdbPlatformString = "Sony Playstation 4";
 
                     break;
 
-                case "PSP":
+                case "SonyPSP":
                     tgdbPlatformString = "Sony PSP";
 
                     break;
 
-                case "TurboGrafx 16":
+                case "TurboGrafx16":
                     tgdbPlatformString = "TurboGrafx 16";
 
                     break;
 
-                case "TurboGrafx CD":
+                case "TurboGrafxCD":
                     tgdbPlatformString = "TurboGrafx CD";
                     break;
 
-                case "ZX Spectrum":
+                case "ZxSpectrum":
                     tgdbPlatformString = "ZX Spectrum";
                     break;
+
+#if DEBUG
+                default:
+                    throw new ArgumentException($"Unrecognized game system: {gameSystem}.");
+#endif
             }
 
             return tgdbPlatformString;

--- a/GameBrowser/Providers/GamesDb/GamesDbGameProvider.cs
+++ b/GameBrowser/Providers/GamesDb/GamesDbGameProvider.cs
@@ -1,22 +1,23 @@
 ﻿using GameBrowser.Extensions;
+using GameBrowser.Resolvers;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.IO;
 using MediaBrowser.Model.Logging;
 using MediaBrowser.Model.Providers;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
-using System.Linq;
-using MediaBrowser.Model.IO;
 
 namespace GameBrowser.Providers.GamesDb
 {
@@ -209,7 +210,7 @@ namespace GameBrowser.Providers.GamesDb
             cancellationToken.ThrowIfCancellationRequested();
 
             var name = item.Name;
-            var platform = GetTgdbPlatformFromGameSystem(item.GameSystem);
+            var platform = ResolverHelper.GetExtendedInfoFromGameSystem(item.GameSystem)?.TgbdPlatform;
             var year = item.Year;
 
             foreach (var re in NameMatches)
@@ -225,8 +226,7 @@ namespace GameBrowser.Providers.GamesDb
 
                         if (yearValue != null && !string.IsNullOrWhiteSpace(yearValue.Value))
                         {
-                            int yearNum;
-                            if (Int32.TryParse(yearValue.Value, out yearNum))
+                            if (Int32.TryParse(yearValue.Value, out int yearNum))
                             {
                                 year = yearNum;
                             }
@@ -617,267 +617,5 @@ namespace GameBrowser.Providers.GamesDb
 
             return GenreMap.ContainsKey(g) ? GenreMap[g] : "";
         }
-        private string GetTgdbPlatformFromGameSystem(string gameSystem)
-        {
-            string tgdbPlatformString = null;
-
-            switch (gameSystem)
-            {
-                case "Panasonic3DO":
-                    tgdbPlatformString = "3DO";
-
-                    break;
-
-                case "Amiga":
-                    tgdbPlatformString = "Amiga";
-
-                    break;
-
-                case "Arcade":
-                    tgdbPlatformString = "Arcade";
-
-                    break;
-
-                case "Atari2600":
-                    tgdbPlatformString = "Atari 2600";
-
-                    break;
-
-                case "Atari5200":
-                    tgdbPlatformString = "Atari 5200";
-
-                    break;
-
-                case "Atari7800":
-                    tgdbPlatformString = "Atari 7800";
-
-                    break;
-
-                case "AtariST":
-                    tgdbPlatformString = "Atari ST";
-
-                    break;
-
-                case "AtariXE":
-                    tgdbPlatformString = "Atari XE";
-
-                    break;
-
-                case "AtariJaguar":
-                    tgdbPlatformString = "Atari Jaguar";
-
-                    break;
-
-                case "AtariJaguarCD":
-                    tgdbPlatformString = "Atari Jaguar CD";
-
-                    break;
-
-                case "AtariLynx":
-                    tgdbPlatformString = "Atari Lynx";
-
-                    break;
-
-                case "Colecovision":
-                    tgdbPlatformString = "Colecovision";
-
-                    break;
-
-                case "Commodore64":
-                    tgdbPlatformString = "Commodore 64";
-
-                    break;
-
-                case "CommodoreVic20":
-                    tgdbPlatformString = "Commodore Vic-20";
-
-                    break;
-
-                case "Intellivision":
-                    tgdbPlatformString = "Intellivision";
-
-                    break;
-
-                case "MicrosoftXBox":
-                    tgdbPlatformString = "Microsoft Xbox";
-
-                    break;
-
-                case "MicrosoftXBox360":
-                    tgdbPlatformString = "Microsoft Xbox 360";
-
-                    break;
-
-                case "MicrosoftXBoxOne":
-                    tgdbPlatformString = "Microsoft Xbox One";
-
-                    break;
-
-                case "NeoGeo":
-                    tgdbPlatformString = "NeoGeo";
-
-                    break;
-
-                case "NeoGeoPocket":
-                    tgdbPlatformString = "Neo Geo Pocket";
-
-                    break;
-
-                case "NeoGeoPocketColor":
-                    tgdbPlatformString = "Neo Geo Pocket Color";
-
-                    break;
-
-                case "Nintendo64":
-                    tgdbPlatformString = "Nintendo 64";
-                    break;
-
-                case "NintendoDS":
-                    tgdbPlatformString = "Nintendo DS";
-
-                    break;
-
-                case "Nintendo":
-                    tgdbPlatformString = "Nintendo Entertainment System (NES)";
-
-                    break;
-
-                case "NintendoGameBoy":
-                    tgdbPlatformString = "Nintendo Game Boy";
-
-                    break;
-
-                case "NintendoGameBoyAdvance":
-                    tgdbPlatformString = "Nintendo Game Boy Advance";
-
-                    break;
-
-                case "NintendoGameBoyColor":
-                    tgdbPlatformString = "Nintendo Game Boy Color";
-
-                    break;
-
-                case "NintendoGameCube":
-                    tgdbPlatformString = "Nintendo GameCube";
-
-                    break;
-
-                case "SuperNintendo":
-                    tgdbPlatformString = "Super Nintendo (SNES)";
-
-                    break;
-
-                case "VirtualBoy":
-                    tgdbPlatformString = "Nintendo Virtual Boy";
-
-                    break;
-
-                case "Wii":
-                    tgdbPlatformString = "Nintendo Wii";
-
-                    break;
-
-                case "WiiU":
-                    tgdbPlatformString = "Nintendo Wii U";
-
-                    break;
-
-                case "DOS":
-                    tgdbPlatformString = "PC";
-
-                    break;
-
-                case "Windows":
-                    tgdbPlatformString = "PC";
-
-                    break;
-
-                case "Sega32X":
-                    tgdbPlatformString = "Sega 32X";
-
-                    break;
-
-                case "SegaCD":
-                    tgdbPlatformString = "Sega CD";
-
-                    break;
-
-                case "SegaDreamcast":
-                    tgdbPlatformString = "Sega Dreamcast";
-
-                    break;
-
-                case "SegaGameGear":
-                    tgdbPlatformString = "Sega Game Gear";
-
-                    break;
-
-                case "SegaGenesis":
-                    tgdbPlatformString = "Sega Genesis";
-
-                    break;
-
-                case "SegaMasterSystem":
-                    tgdbPlatformString = "Sega Master System";
-
-                    break;
-
-                case "SegaMegaDrive":
-                    tgdbPlatformString = "Sega Genesis";
-
-                    break;
-
-                case "SegaSaturn":
-                    tgdbPlatformString = "Sega Saturn";
-
-                    break;
-
-                case "SonyPlaystation":
-                    tgdbPlatformString = "Sony Playstation";
-
-                    break;
-
-                case "SonyPlaystation2":
-                    tgdbPlatformString = "Sony Playstation 2";
-
-                    break;
-
-                case "SonyPlaystation3":
-                    tgdbPlatformString = "Sony Playstation 3";
-
-                    break;
-
-                case "SonyPlaystation4":
-                    tgdbPlatformString = "Sony Playstation 4";
-
-                    break;
-
-                case "SonyPSP":
-                    tgdbPlatformString = "Sony PSP";
-
-                    break;
-
-                case "TurboGrafx16":
-                    tgdbPlatformString = "TurboGrafx 16";
-
-                    break;
-
-                case "TurboGrafxCD":
-                    tgdbPlatformString = "TurboGrafx CD";
-                    break;
-
-                case "ZxSpectrum":
-                    tgdbPlatformString = "ZX Spectrum";
-                    break;
-
-#if DEBUG
-                default:
-                    throw new ArgumentException($"Unrecognized game system: {gameSystem}.");
-#endif
-            }
-
-            return tgdbPlatformString;
-        }
-
     }
 }

--- a/GameBrowser/Providers/GamesDb/GamesDbGameProvider.cs
+++ b/GameBrowser/Providers/GamesDb/GamesDbGameProvider.cs
@@ -713,6 +713,16 @@ namespace GameBrowser.Providers.GamesDb
 
                     break;
 
+                case "NeoGeoPocket":
+                    tgdbPlatformString = "Neo Geo Pocket";
+
+                    break;
+
+                case "NeoGeoPocketColor":
+                    tgdbPlatformString = "Neo Geo Pocket Color";
+
+                    break;
+
                 case "Nintendo64":
                     tgdbPlatformString = "Nintendo 64";
                     break;

--- a/GameBrowser/Providers/GamesDb/GamesDbGameSystemProvider.cs
+++ b/GameBrowser/Providers/GamesDb/GamesDbGameSystemProvider.cs
@@ -156,11 +156,9 @@ namespace GameBrowser.Providers.GamesDb
         public string FindPlatformId(GameSystemInfo console)
         {
             var platformSettings = Plugin.Instance.Configuration.GameSystems.FirstOrDefault(gs => console.Path.Equals(gs.Path));
-
             if (platformSettings != null)
             {
-                var id = ResolverHelper.GetTgdbId(platformSettings.ConsoleType);
-
+                var id = ResolverHelper.GetExtendedInfoFromConsoleType(platformSettings.ConsoleType)?.TgbdId;
                 if (id != null)
                 {
                     return id.ToString();

--- a/GameBrowser/Resolvers/GameResolver.cs
+++ b/GameBrowser/Resolvers/GameResolver.cs
@@ -104,7 +104,7 @@ namespace GameBrowser.Resolvers
 
             if (gameFiles.Count == 0)
             {
-                _logger.Error("gameFiles is 0 for " + args.Path);
+                _logger.Error($"gameFiles is 0 for {args.Path}. Expected: {string.Join(";", validExtensions)}. Found: {string.Join(";", args.FileSystemChildren.Where(f => !f.IsDirectory).Select(f => Path.GetExtension(f.FullName)).Distinct())}.");
                 return null;
             }
 
@@ -134,7 +134,7 @@ namespace GameBrowser.Resolvers
                     return new[] { ".iso", ".cue" };
 
                 case "Amiga":
-                    return new[] { ".iso", ".adf" };
+                    return new[] { ".iso", ".adf", ".ipf" };
 
                 case "Arcade":
                     return new[] { ".zip" };
@@ -157,11 +157,14 @@ namespace GameBrowser.Resolvers
                 case "Atari Jaguar CD": // still need to verify
                     return new[] { ".iso" };
 
+                case "Atari Lynx":
+                    return new[] { ".lnx" };
+
                 case "Colecovision":
                     return new[] { ".col", ".rom" };
 
                 case "Commodore 64":
-                    return new[] { ".d64", ".g64", ".prg", ".tap", ".t64" };
+                    return new[] { ".crt", ".d64", ".g64", ".prg", ".tap", ".t64" };
 
                 case "Commodore Vic-20":
                     return new[] { ".prg" };

--- a/GameBrowser/Resolvers/GameResolver.cs
+++ b/GameBrowser/Resolvers/GameResolver.cs
@@ -184,6 +184,12 @@ namespace GameBrowser.Resolvers
                 case "Neo Geo":
                     return new[] { ".zip", ".iso" };
 
+                case "Neo Geo Pocket":
+                    return new[] { ".ngp" };
+
+                case "Neo Geo Pocket Color":
+                    return new[] { ".ngc" };
+
                 case "Nintendo 64":
                     return new[] { ".z64", ".v64", ".usa", ".jap", ".pal", ".rom", ".n64", ".zip" };
 

--- a/GameBrowser/Resolvers/GameResolver.cs
+++ b/GameBrowser/Resolvers/GameResolver.cs
@@ -92,17 +92,12 @@ namespace GameBrowser.Resolvers
         /// <returns>A Game</returns>
         private Game GetGame(ItemResolveArgs args, string consoleType)
         {
-            var validExtensions = GetExtensions(consoleType);
+            var gameSystemDefinition = ResolverHelper.GetExtendedInfoFromConsoleType(consoleType);
+            var validExtensions = gameSystemDefinition?.Extensions;
 
-            var gameFiles = args.FileSystemChildren.Where(f =>
-            {
-                var fileExtension = Path.GetExtension(f.FullName);
+            var gameFiles = args.FileSystemChildren.Where(f => validExtensions.Contains(Path.GetExtension(f.FullName), StringComparer.OrdinalIgnoreCase)).ToArray();
 
-                return validExtensions.Contains(fileExtension, StringComparer.OrdinalIgnoreCase);
-
-            }).ToList();
-
-            if (gameFiles.Count == 0)
+            if (gameFiles.Length == 0)
             {
                 _logger.Error($"gameFiles is 0 for {args.Path}. Expected: {string.Join(";", validExtensions)}. Found: {string.Join(";", args.FileSystemChildren.Where(f => !f.IsDirectory).Select(f => Path.GetExtension(f.FullName)).Distinct())}.");
                 return null;
@@ -111,179 +106,18 @@ namespace GameBrowser.Resolvers
             var game = new Game
             {
                 Path = gameFiles[0].FullName,
-                GameSystem = ResolverHelper.GetGameSystemFromPlatform(consoleType)
+                GameSystem = gameSystemDefinition?.Name
             };
 
             game.IsPlaceHolder = false;
                 
-            if (gameFiles.Count > 1)
+            if (gameFiles.Length > 1)
             {
                 game.MultiPartGameFiles = gameFiles.Select(i => i.FullName).ToArray();
                 game.IsMultiPart = true;
             }
 
             return game;
-        }
-
-
-        private IEnumerable<string> GetExtensions(string consoleType)
-        {
-            switch (consoleType)
-            {
-                case "3DO":
-                    return new[] { ".iso", ".cue" };
-
-                case "Amiga":
-                    return new[] { ".iso", ".adf", ".ipf" };
-
-                case "Arcade":
-                    return new[] { ".zip" };
-
-                case "Atari 2600":
-                    return new[] { ".bin", ".a26" };
-
-                case "Atari 5200":
-                    return new[] { ".bin", ".a52" };
-
-                case "Atari 7800":
-                    return new[] { ".a78" };
-
-                case "Atari ST":
-                    return new[] { ".ipf" };
-
-                case "Atari XE":
-                    return new[] { ".rom" };
-
-                case "Atari Jaguar":
-                    return new[] { ".j64", ".zip" };
-
-                case "Atari Jaguar CD": // still need to verify
-                    return new[] { ".iso" };
-
-                case "Atari Lynx":
-                    return new[] { ".lnx" };
-
-                case "Colecovision":
-                    return new[] { ".col", ".rom" };
-
-                case "Commodore 64":
-                    return new[] { ".crt", ".d64", ".g64", ".prg", ".tap", ".t64" };
-
-                case "Commodore Vic-20":
-                    return new[] { ".prg" };
-
-                case "Intellivision":
-                    return new[] { ".int", ".rom" };
-
-                case "Xbox":
-                    return new[] { ".disc", ".iso" };
-
-                case "Xbox 360":
-                    return new[] { ".disc" };
-
-                case "Xbox One":
-                    return new[] { ".disc" };
-
-                case "Neo Geo":
-                    return new[] { ".zip", ".iso" };
-
-                case "Neo Geo Pocket":
-                    return new[] { ".ngp" };
-
-                case "Neo Geo Pocket Color":
-                    return new[] { ".ngc" };
-
-                case "Nintendo 64":
-                    return new[] { ".z64", ".v64", ".usa", ".jap", ".pal", ".rom", ".n64", ".zip" };
-
-                case "Nintendo DS":
-                    return new[] { ".nds", ".zip" };
-
-                case "Nintendo":
-                    return new[] { ".nes", ".zip" };
-
-                case "Game Boy":
-                    return new[] { ".gb", ".zip" };
-
-                case "Game Boy Advance":
-                    return new[] { ".gba", ".zip" };
-
-                case "Game Boy Color":
-                    return new[] { ".gbc", ".zip" };
-
-                case "Gamecube":
-                    return new[] { ".iso", ".bin", ".img", ".gcm", ".gcz" };
-
-                case "Super Nintendo":
-                    return new[] { ".smc", ".zip", ".fam", ".rom", ".sfc", ".fig" };
-
-                case "Virtual Boy":
-                    return new[] { ".vb" };
-
-                case "Nintendo Wii":
-                    return new[] { ".iso", ".dol", ".ciso", ".wbfs", ".wad", ".gcz" };
-
-                case "Nintendo Wii U":
-                    return new[] { ".disc", ".wud" };
-
-                case "DOS":
-                    return new[] { ".gbdos", ".disc" };
-
-                case "Windows":
-                    return new[] { ".gbwin", ".disc" };
-
-                case "Sega 32X":
-                    return new[] { ".iso", ".bin", ".img", ".zip", ".32x" };
-
-                case "Sega CD":
-                    return new[] { ".iso", ".bin", ".img" };
-
-                case "Dreamcast":
-                    return new[] { ".chd", ".gdi", ".cdi" };
-
-                case "Game Gear":
-                    return new[] { ".gg", ".zip" };
-
-                case "Sega Genesis":
-                    return new[] { ".smd", ".bin", ".gen", ".zip", ".md" };
-
-                case "Sega Master System":
-                    return new[] { ".sms", ".sg", ".sc", ".zip" };
-
-                case "Sega Mega Drive":
-                    return new[] { ".smd", ".zip", ".md" };
-
-                case "Sega Saturn":
-                    return new[] { ".iso", ".bin", ".img" };
-
-                case "Sony Playstation":
-                    return new[] { ".iso", ".cue", ".img", ".ps1", ".pbp" };
-
-                case "PS2":
-                    return new[] { ".iso", ".bin" };
-
-                case "PS3":
-                    return new[] { ".disc" };
-
-                case "PS4":
-                    return new[] { ".disc" };
-
-                case "PSP":
-                    return new[] { ".iso", ".cso" };
-
-                case "TurboGrafx 16":
-                    return new[] { ".pce", ".zip" };
-
-                case "TurboGrafx CD":
-                    return new[] { ".bin", ".iso" };
-
-                case "ZX Spectrum":
-                    return new[] { ".z80", ".tap", ".tzx" };
-
-                default:
-                    return new string[] { };
-            }
-
         }
     }
 }

--- a/GameBrowser/Resolvers/GameResolver.cs
+++ b/GameBrowser/Resolvers/GameResolver.cs
@@ -148,6 +148,9 @@ namespace GameBrowser.Resolvers
                 case "Atari 7800":
                     return new[] { ".a78" };
 
+                case "Atari ST":
+                    return new[] { ".ipf" };
+
                 case "Atari XE":
                     return new[] { ".rom" };
 

--- a/GameBrowser/Resolvers/GameSystemDefinition.cs
+++ b/GameBrowser/Resolvers/GameSystemDefinition.cs
@@ -535,46 +535,5 @@
                     EmuMoviesPlatform = "Sony_PSP"
                 }
         };
-
-        // This method was not used. Making a commit to have it in history then deleting.
-        // public static string GetDisplayMediaTypeFromPlatform(string platform)
-        //     "3DO" => "Panasonic3doGame";
-        //     "Atari XE" => "AtariXeGame";
-        //     "Atari Jaguar" => "JaguarGame";
-        //     "Atari Jaguar CD"=>"JaguarGame";
-        //     "Commodore 64" => "C64Game";
-        //     "Commodore Vic-20" => "Vic20Game";
-        //     "Xbox" => "XboxGame";
-        //     "Xbox 360" => "Xbox360Game";
-        //     "Xbox One" => "XboxOneGame";
-        //     "Nintendo 64" => "N64Game";
-        //     "Nintendo DS" => "NesGame";
-        //     "Nintendo" => "NesGame";
-        //     "Game Boy" => "GameBoyGame";
-        //     "Game Boy Advance" => "GameBoyAdvanceGame";
-        //     "Game Boy Color" => "GameBoyColorGame";
-        //     "Gamecube" => "GameCubeGame";
-        //     "Super Nintendo" => "SnesGame";
-        //     "Virtual Boy" => "NesGame";
-        //     "Nintendo Wii" => "NesGame";
-        //     "Nintendo Wii U" => "WiiUGame";
-        //     "DOS" => "DosGame";
-        //     "Windows" => "WindowsGame";
-        //     "Sega 32X" => "GenesisGame";
-        //     "Sega CD" => "GenesisGame";
-        //     "Dreamcast" => "GenesisGame";
-        //     "Game Gear" => "GenesisGame";
-        //     "Sega Genesis" => "GenesisGame";
-        //     "Sega Master System" => "GenesisGame";
-        //     "Sega Mega Drive" => "GenesisGame";
-        //     "Sega Saturn" => "GenesisGame";
-        //     "Sony Playstation" => "PsOneGame";
-        //     "PS2" => "Ps2Game";
-        //     "PS3" => "Ps3Game";
-        //     "PS4" => "Ps4Game";
-        //     "PSP" => "PlayStationPortableGame";
-        //     "TurboGrafx 16" => "TurboGrafx16Game";
-        //     "TurboGrafx CD" => "TurboGrafx16Game";
-        //     "ZX Spectrum" => "ZXSpectrumGame";
     }
 }

--- a/GameBrowser/Resolvers/GameSystemDefinition.cs
+++ b/GameBrowser/Resolvers/GameSystemDefinition.cs
@@ -120,7 +120,7 @@
                 {
                     ConsoleType = "Commodore 64",
                     Name = "Commodore64",
-                    Extensions = new[] { ".zip", ".7z", ".crt", ".d64", ".g64", ".prg", ".tap", ".t64" },
+                    Extensions = new[] { ".zip", ".7z", ".crt", ".d64", ".g64", ".prg", ".tap", ".t64", ".bin" },
                     TgbdId = 40,
                     TgbdPlatform = "Commodore 64",
                     EmuMoviesPlatform = "Commodore_64"
@@ -130,7 +130,7 @@
                 {
                     ConsoleType = "Amiga",
                     Name = "Amiga",
-                    Extensions = new[] { ".iso", ".adf", ".ipf" },
+                    Extensions = new[] { ".iso", ".adf", ".ipf", ".rom" },
                     TgbdId = 4911,
                     TgbdPlatform = "Amiga",
                     EmuMoviesPlatform = null
@@ -314,7 +314,7 @@
                 {
                     ConsoleType = "Super Nintendo",
                     Name = "SuperNintendo",
-                    Extensions = new[] { ".zip", ".7z", ".smc", ".fam", ".rom", ".sfc", ".fig" },
+                    Extensions = new[] { ".zip", ".7z", ".smc", ".fam", ".rom", ".sfc", ".fig", ".bin" },
                     TgbdId = 6,
                     TgbdPlatform = "Super Nintendo (SNES)",
                     EmuMoviesPlatform = "Nintendo_SNES"

--- a/GameBrowser/Resolvers/GameSystemDefinition.cs
+++ b/GameBrowser/Resolvers/GameSystemDefinition.cs
@@ -1,0 +1,580 @@
+﻿namespace GameBrowser.Resolvers
+{
+    public class GameSystemDefinition
+    {
+        public string Name { get; internal set; }
+        public string ConsoleType { get; internal set; }
+        public string[] Extensions { get; internal set; }
+
+        public int TgbdId { get; internal set; }
+        public string TgbdPlatform { get; internal set; }
+        public string EmuMoviesPlatform { get; internal set; }
+
+        public static GameSystemDefinition[] All = new[]
+        {
+                // Arcade
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Arcade",
+                    Name = "Arcade",
+                    Extensions = new[] { ".zip" },
+                    TgbdId = 23,
+                    TgbdPlatform = "Arcade",
+                    EmuMoviesPlatform = "MAME"
+                },
+
+                // Atari - 2600
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Atari 2600",
+                    Name = "Atari2600",
+                    Extensions = new[] { ".bin", ".a26" },
+                    TgbdId = 22,
+                    TgbdPlatform = "Atari 2600",
+                    EmuMoviesPlatform = "Atari_2600"
+                },
+                // Atari - 5200
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Atari 5200",
+                    Name = "Atari5200",
+                    Extensions = new[] { ".bin", ".a52" },
+                    TgbdId = 26,
+                    TgbdPlatform = "Atari 5200",
+                    EmuMoviesPlatform = "Atari_5200"
+                },
+                // Atari - 7800
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Atari 7800",
+                    Name = "Atari7800",
+                    Extensions = new[] { ".a78" },
+                    TgbdId = 27,
+                    TgbdPlatform = "Atari 7800",
+                    EmuMoviesPlatform = "Atari_7800"
+                },
+                // Atari - Jaguar
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Atari Jaguar",
+                    Name = "AtariJaguar",
+                    Extensions = new[] { ".j64", ".zip" },
+                    TgbdId = 28,
+                    TgbdPlatform = "Atari Jaguar",
+                    EmuMoviesPlatform = "Atari_Jaguar"
+                },
+                // Atari - Jaguar CD
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Atari Jaguar CD",
+                    Name = "AtariJaguarCD",
+                    Extensions = new[] { ".iso" },
+                    TgbdId = 29,
+                    TgbdPlatform = "Atari Jaguar CD",
+                    EmuMoviesPlatform = "Atari_Jaguar"
+                },
+                // Atari - Lynx
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Atari Lynx",
+                    Name = "AtariLynx",
+                    Extensions = new[] { ".lnx" },
+                    TgbdId = 4924,
+                    TgbdPlatform = "Atari Lynx",
+                    EmuMoviesPlatform = null
+                },
+                // Atari - ST
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Atari ST",
+                    Name = "AtariST",
+                    Extensions = new[] { ".ipf" },
+                    TgbdId = 4937,
+                    TgbdPlatform = "Atari ST",
+                    EmuMoviesPlatform = null
+                },
+                // Atari - XE
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Atari XE",
+                    Name = "AtariXE",
+                    Extensions = new[] { ".rom" },
+                    TgbdId = 30,
+                    TgbdPlatform = "Atari XE",
+                    EmuMoviesPlatform = "Atari_8_bit"
+                },
+
+                // Coleco - Colecovision
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Colecovision",
+                    Name = "Colecovision",
+                    Extensions = new[] { ".col", ".rom" },
+                    TgbdId = 31,
+                    TgbdPlatform = "Colecovision",
+                    EmuMoviesPlatform = "Coleco_Vision"
+                },
+                
+                // Commodore - 64
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Commodore 64",
+                    Name = "Commodore64",
+                    Extensions = new[] { ".crt", ".d64", ".g64", ".prg", ".tap", ".t64" },
+                    TgbdId = 40,
+                    TgbdPlatform = "Commodore 64",
+                    EmuMoviesPlatform = "Commodore_64"
+                },
+                // Commodore - Amiga
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Amiga",
+                    Name = "Amiga",
+                    Extensions = new[] { ".iso", ".adf", ".ipf" },
+                    TgbdId = 4911,
+                    TgbdPlatform = "Amiga",
+                    EmuMoviesPlatform = null
+                },
+                // Commodore - Vic-20
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Commodore Vic-20",
+                    Name = "CommodoreVic20",
+                    Extensions = new[] { ".prg" },
+                    TgbdId = 4945,
+                    TgbdPlatform = "Commodore Vic-20",
+                    EmuMoviesPlatform = null
+                },
+
+                // Matel - Intellivision
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Intellivision",
+                    Name = "Intellivision",
+                    Extensions = new[] { ".int", ".rom" },
+                    TgbdId = 32,
+                    TgbdPlatform = "Intellivision",
+                    EmuMoviesPlatform = "Mattel_Intellivision"
+                },
+
+                // Microsoft - DOS
+                new GameSystemDefinition
+                {
+                    ConsoleType = "DOS",
+                    Name = "DOS",
+                    Extensions = new[] { ".gbdos", ".disc" },
+                    TgbdId = 1,
+                    TgbdPlatform = "PC",
+                    EmuMoviesPlatform = null
+                },
+                // Microsoft - PC
+                new GameSystemDefinition
+                {
+                    ConsoleType = "PC",
+                    Name = "PC",
+                    Extensions = new string[] { },
+                    TgbdId = 1,
+                    TgbdPlatform = "PC",
+                    EmuMoviesPlatform = null
+                },
+                // Microsoft - Xbox
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Xbox",
+                    Name = "MicrosoftXBox",
+                    Extensions = new[] { ".disc", ".iso" },
+                    TgbdId = 14,
+                    TgbdPlatform = "Microsoft Xbox",
+                    EmuMoviesPlatform = "Microsoft_Xbox"
+                },
+                // Microsoft - Xbox 360
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Xbox 360",
+                    Name = "MicrosoftXBox360",
+                    Extensions = new[] { ".disc" },
+                    TgbdId = 15,
+                    TgbdPlatform = "Microsoft Xbox 360",
+                    EmuMoviesPlatform = null
+                },
+                // Microsoft - Xbox One
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Xbox One",
+                    Name = "MicrosoftXBoxOne",
+                    Extensions = new[] { ".disc" },
+                    TgbdId = 4920,
+                    TgbdPlatform = "Microsoft Xbox One",
+                    EmuMoviesPlatform = null
+                },
+                // Microsoft - Windows
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Windows",
+                    Name = "Windows",
+                    Extensions = new[] { ".gbwin", ".disc" },
+                    TgbdId = 1,
+                    TgbdPlatform = "PC",
+                    EmuMoviesPlatform = null
+                },
+
+                // NEC - PC Engine - TurboGrafx 16
+                new GameSystemDefinition
+                {
+                    ConsoleType = "TurboGrafx 16",
+                    Name = "TurboGrafx16",
+                    Extensions = new[] { ".pce", ".zip" },
+                    TgbdId = 34,
+                    TgbdPlatform = "TurboGrafx 16",
+                    EmuMoviesPlatform = "NEC_TurboGrafx_16"
+                },
+                // NEC - PC Engine - TurboGrafx CD
+                new GameSystemDefinition
+                {
+                    ConsoleType = "TurboGrafx CD",
+                    Name = "TurboGrafxCD",
+                    Extensions = new[] { ".bin", ".iso" },
+                    TgbdId = 34,
+                    TgbdPlatform = "TurboGrafx CD",
+                    EmuMoviesPlatform = "NEC_TurboGrafx_16"
+                },
+
+                // Nintendo - Game Boy
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Game Boy",
+                    Name = "NintendoGameBoy",
+                    Extensions = new[] { ".gb", ".zip" },
+                    TgbdId = 4,
+                    TgbdPlatform = "Nintendo Game Boy",
+                    EmuMoviesPlatform = "Nintendo_Game_Boy"
+                },
+                // Nintendo - Game Boy Advance
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Game Boy Advance",
+                    Name = "NintendoGameBoyAdvance",
+                    Extensions = new[] { ".gba", ".zip" },
+                    TgbdId = 5,
+                    TgbdPlatform = "Nintendo Game Boy Advance",
+                    EmuMoviesPlatform = "Nintendo_Game_Boy_Advance"
+                },
+                // Nintendo - Game Boy Color
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Game Boy Color",
+                    Name = "NintendoGameBoyColor",
+                    Extensions = new[] { ".gbc", ".zip" },
+                    TgbdId = 41,
+                    TgbdPlatform = "Nintendo Game Boy Color",
+                    EmuMoviesPlatform = "Nintendo_Game_Boy_Color"
+                },
+                // Nintendo - GameCube
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Gamecube",
+                    Name = "NintendoGameCube",
+                    Extensions = new[] { ".iso", ".bin", ".img", ".gcm", ".gcz" },
+                    TgbdId = 2,
+                    TgbdPlatform = "Nintendo GameCube",
+                    EmuMoviesPlatform = "Nintendo_GameCube"
+                },
+                // Nintendo - Nintendo 64
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Nintendo 64",
+                    Name = "Nintendo64",
+                    Extensions = new[] { ".z64", ".v64", ".usa", ".jap", ".pal", ".rom", ".n64", ".zip" },
+                    TgbdId = 3,
+                    TgbdPlatform = "Nintendo 64",
+                    EmuMoviesPlatform = "Nintendo_N64"
+                },
+                // Nintendo - Nintendo DS
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Nintendo DS",
+                    Name = "NintendoDS",
+                    Extensions = new[] { ".nds", ".zip" },
+                    TgbdId = 8,
+                    TgbdPlatform = "Nintendo DS",
+                    EmuMoviesPlatform = "Nintendo_DS"
+                },
+                // Nintendo - Nintendo Entertainment System
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Nintendo",
+                    Name = "Nintendo",
+                    Extensions = new[] { ".nes", ".zip" },
+                    TgbdId = 7,
+                    TgbdPlatform = "Nintendo Entertainment System (NES)",
+                    EmuMoviesPlatform = "Nintendo_NES"
+                },
+                // Nintendo - Super Nintendo Entertainment System
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Super Nintendo",
+                    Name = "SuperNintendo",
+                    Extensions = new[] { ".smc", ".zip", ".fam", ".rom", ".sfc", ".fig" },
+                    TgbdId = 6,
+                    TgbdPlatform = "Super Nintendo (SNES)",
+                    EmuMoviesPlatform = "Nintendo_SNES"
+                },
+                // Nintendo - Virtual Boy 
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Virtual Boy",
+                    Name = "VirtualBoy",
+                    Extensions = new[] { ".vb" },
+                    TgbdId = 4918,
+                    TgbdPlatform = "Nintendo Virtual Boy",
+                    EmuMoviesPlatform = null
+                },
+                // Nintendo - Wii
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Nintendo Wii",
+                    Name = "Wii",
+                    Extensions = new[] { ".iso", ".dol", ".ciso", ".wbfs", ".wad", ".gcz" },
+                    TgbdId = 9,
+                    TgbdPlatform = "Nintendo Wii",
+                    EmuMoviesPlatform = null
+                },
+                // Nintendo - Wii U
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Nintendo Wii U",
+                    Name = "WiiU",
+                    Extensions = new[] { ".disc", ".wud" },
+                    TgbdId = 38,
+                    TgbdPlatform = "Nintendo Wii U",
+                    EmuMoviesPlatform = ""
+                },
+
+                // Panasonic - 3DO
+                new GameSystemDefinition
+                {
+                    ConsoleType = "3DO",
+                    Name = "Panasonic3DO",
+                    Extensions = new[] { ".iso", ".cue" },
+                    TgbdId = 25,
+                    TgbdPlatform = "3DO",
+                    EmuMoviesPlatform = "Panasonic_3DO"
+                },
+
+                // Sega - 32X
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Sega 32X",
+                    Name = "Sega32X",
+                    Extensions = new[] { ".iso", ".bin", ".img", ".zip", ".32x" },
+                    TgbdId = 33,
+                    TgbdPlatform = "Sega 32X",
+                    EmuMoviesPlatform = "Sega_Genesis"
+                },
+                // Sega - CD
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Sega CD",
+                    Name = "SegaCD",
+                    Extensions = new[] { ".iso", ".bin", ".img" },
+                    TgbdId = 21,
+                    TgbdPlatform = "Sega CD",
+                    EmuMoviesPlatform = "Sega_Genesis"
+                },
+                // Sega - Dreamcast
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Dreamcast",
+                    Name = "SegaDreamcast",
+                    Extensions = new[] { ".chd", ".gdi", ".cdi" },
+                    TgbdId = 16,
+                    TgbdPlatform = "Sega Dreamcast",
+                    EmuMoviesPlatform = "Sega_Dreamcast"
+                },
+                // Sega - Game Gear
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Game Gear",
+                    Name = "SegaGameGear",
+                    Extensions = new[] { ".gg", ".zip" },
+                    TgbdId = 20,
+                    TgbdPlatform = "Sega Game Gear",
+                    EmuMoviesPlatform = "Sega_Game_Gear"
+                },
+                // Sega - Mega Drive
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Sega Mega Drive",
+                    Name = "SegaMegaDrive",
+                    Extensions = new[] { ".smd", ".zip", ".md" },
+                    TgbdId = 36,
+                    TgbdPlatform = "Sega Genesis",
+                    EmuMoviesPlatform = "Sega_Genesis"
+                },
+                // Sega - Mega Drive - Genesis
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Sega Genesis",
+                    Name = "SegaGenesis",
+                    Extensions = new[] { ".smd", ".bin", ".gen", ".zip", ".md" },
+                    TgbdId = 18,
+                    TgbdPlatform = "Sega Genesis",
+                    EmuMoviesPlatform = "Sega_Genesis"
+                },
+                // Sega - Master System - Mark III
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Sega Master System",
+                    Name = "SegaMasterSystem",
+                    Extensions = new[] { ".sms", ".sg", ".sc", ".zip" },
+                    TgbdId = 35,
+                    TgbdPlatform = "Sega Master System",
+                    EmuMoviesPlatform = "Sega_Master_System"
+                },
+                // Sega - Saturn
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Sega Saturn",
+                    Name = "SegaSaturn",
+                    Extensions = new[] { ".iso", ".bin", ".img" },
+                    TgbdId = 17,
+                    TgbdPlatform = "Sega Saturn",
+                    EmuMoviesPlatform = "Sega_Saturn"
+                },
+
+                // Sinclair - ZX Spectrum 
+                new GameSystemDefinition
+                {
+                    ConsoleType = "ZX Spectrum",
+                    Name = "ZxSpectrum",
+                    Extensions = new[] { ".z80", ".tap", ".tzx" },
+                    TgbdId = 4913,
+                    TgbdPlatform = "ZX Spectrum",
+                    EmuMoviesPlatform = null
+                },
+
+                // SNK - Neo Geo
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Neo Geo",
+                    Name = "NeoGeo",
+                    Extensions = new[] { ".zip", ".iso" },
+                    TgbdId = 24,
+                    TgbdPlatform = "NeoGeo",
+                    EmuMoviesPlatform = "SNK_Neo_Geo_AES"
+                },
+                // SNK - Neo Geo Pocket
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Neo Geo Pocket",
+                    Name = "NeoGeoPocket",
+                    Extensions = new[] { ".ngp" },
+                    TgbdId = 4922,
+                    TgbdPlatform = "Neo Geo Pocket",
+                    EmuMoviesPlatform = null
+                },
+                // SNK - Neo Geo Pocket Color 
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Neo Geo Pocket Color",
+                    Name = "NeoGeoPocketColor",
+                    Extensions = new[] { ".ngc" },
+                    TgbdId = 4923,
+                    TgbdPlatform = "Neo Geo Pocket Color",
+                    EmuMoviesPlatform = null
+                },
+
+                // Sony - Playstation
+                new GameSystemDefinition
+                {
+                    ConsoleType = "Sony Playstation",
+                    Name = "SonyPlaystation",
+                    Extensions = new[] { ".iso", ".cue", ".img", ".ps1", ".pbp" },
+                    TgbdId = 10,
+                    TgbdPlatform = "Sony Playstation",
+                    EmuMoviesPlatform = "Sony_Playstation"
+                },
+                // Sony - Playstation 2
+                new GameSystemDefinition
+                {
+                    ConsoleType = "PS2",
+                    Name = "SonyPlaystation2",
+                    Extensions = new[] { ".iso", ".bin" },
+                    TgbdId = 11,
+                    TgbdPlatform = "Sony Playstation 2",
+                    EmuMoviesPlatform = "Sony_Playstation_2"
+                },
+                // Sony - Playstation 3
+                new GameSystemDefinition
+                {
+                    ConsoleType = "PS3",
+                    Name = "SonyPlaystation3",
+                    Extensions = new[] { ".disc" },
+                    TgbdId = 12,
+                    TgbdPlatform = "Sony Playstation 3",
+                    EmuMoviesPlatform = ""
+                },
+                // Sony - Playstation 4
+                new GameSystemDefinition
+                {
+                    ConsoleType = "PS4",
+                    Name = "SonyPlaystation4",
+                    Extensions = new[] { ".disc" },
+                    TgbdId = 4919,
+                    TgbdPlatform = "Sony Playstation 4",
+                    EmuMoviesPlatform = ""
+                },
+                // Sony - PlayStation Portable
+                new GameSystemDefinition
+                {
+                    ConsoleType = "PSP",
+                    Name = "SonyPSP",
+                    Extensions = new[] { ".iso", ".cso" },
+                    TgbdId = 13,
+                    TgbdPlatform = "Sony PSP",
+                    EmuMoviesPlatform = "Sony_PSP"
+                }
+        };
+
+        // This method was not used. Making a commit to have it in history then deleting.
+        // public static string GetDisplayMediaTypeFromPlatform(string platform)
+        //     "3DO" => "Panasonic3doGame";
+        //     "Atari XE" => "AtariXeGame";
+        //     "Atari Jaguar" => "JaguarGame";
+        //     "Atari Jaguar CD"=>"JaguarGame";
+        //     "Commodore 64" => "C64Game";
+        //     "Commodore Vic-20" => "Vic20Game";
+        //     "Xbox" => "XboxGame";
+        //     "Xbox 360" => "Xbox360Game";
+        //     "Xbox One" => "XboxOneGame";
+        //     "Nintendo 64" => "N64Game";
+        //     "Nintendo DS" => "NesGame";
+        //     "Nintendo" => "NesGame";
+        //     "Game Boy" => "GameBoyGame";
+        //     "Game Boy Advance" => "GameBoyAdvanceGame";
+        //     "Game Boy Color" => "GameBoyColorGame";
+        //     "Gamecube" => "GameCubeGame";
+        //     "Super Nintendo" => "SnesGame";
+        //     "Virtual Boy" => "NesGame";
+        //     "Nintendo Wii" => "NesGame";
+        //     "Nintendo Wii U" => "WiiUGame";
+        //     "DOS" => "DosGame";
+        //     "Windows" => "WindowsGame";
+        //     "Sega 32X" => "GenesisGame";
+        //     "Sega CD" => "GenesisGame";
+        //     "Dreamcast" => "GenesisGame";
+        //     "Game Gear" => "GenesisGame";
+        //     "Sega Genesis" => "GenesisGame";
+        //     "Sega Master System" => "GenesisGame";
+        //     "Sega Mega Drive" => "GenesisGame";
+        //     "Sega Saturn" => "GenesisGame";
+        //     "Sony Playstation" => "PsOneGame";
+        //     "PS2" => "Ps2Game";
+        //     "PS3" => "Ps3Game";
+        //     "PS4" => "Ps4Game";
+        //     "PSP" => "PlayStationPortableGame";
+        //     "TurboGrafx 16" => "TurboGrafx16Game";
+        //     "TurboGrafx CD" => "TurboGrafx16Game";
+        //     "ZX Spectrum" => "ZXSpectrumGame";
+    }
+}

--- a/GameBrowser/Resolvers/GameSystemDefinition.cs
+++ b/GameBrowser/Resolvers/GameSystemDefinition.cs
@@ -28,7 +28,7 @@
                 {
                     ConsoleType = "Atari 2600",
                     Name = "Atari2600",
-                    Extensions = new[] { ".bin", ".a26" },
+                    Extensions = new[] { ".zip", ".7z", ".bin", ".a26" },
                     TgbdId = 22,
                     TgbdPlatform = "Atari 2600",
                     EmuMoviesPlatform = "Atari_2600"
@@ -38,7 +38,7 @@
                 {
                     ConsoleType = "Atari 5200",
                     Name = "Atari5200",
-                    Extensions = new[] { ".bin", ".a52" },
+                    Extensions = new[] { ".zip", ".7z", ".bin", ".a52" },
                     TgbdId = 26,
                     TgbdPlatform = "Atari 5200",
                     EmuMoviesPlatform = "Atari_5200"
@@ -48,7 +48,7 @@
                 {
                     ConsoleType = "Atari 7800",
                     Name = "Atari7800",
-                    Extensions = new[] { ".a78" },
+                    Extensions = new[] { ".zip", ".7z", ".a78" },
                     TgbdId = 27,
                     TgbdPlatform = "Atari 7800",
                     EmuMoviesPlatform = "Atari_7800"
@@ -58,7 +58,7 @@
                 {
                     ConsoleType = "Atari Jaguar",
                     Name = "AtariJaguar",
-                    Extensions = new[] { ".j64", ".zip" },
+                    Extensions = new[] { ".zip", ".7z", ".j64" },
                     TgbdId = 28,
                     TgbdPlatform = "Atari Jaguar",
                     EmuMoviesPlatform = "Atari_Jaguar"
@@ -78,7 +78,7 @@
                 {
                     ConsoleType = "Atari Lynx",
                     Name = "AtariLynx",
-                    Extensions = new[] { ".lnx" },
+                    Extensions = new[] { ".zip", ".7z", ".lnx" },
                     TgbdId = 4924,
                     TgbdPlatform = "Atari Lynx",
                     EmuMoviesPlatform = null
@@ -98,7 +98,7 @@
                 {
                     ConsoleType = "Atari XE",
                     Name = "AtariXE",
-                    Extensions = new[] { ".rom" },
+                    Extensions = new[] { ".zip", ".7z", ".rom" },
                     TgbdId = 30,
                     TgbdPlatform = "Atari XE",
                     EmuMoviesPlatform = "Atari_8_bit"
@@ -109,7 +109,7 @@
                 {
                     ConsoleType = "Colecovision",
                     Name = "Colecovision",
-                    Extensions = new[] { ".col", ".rom" },
+                    Extensions = new[] { ".zip", ".7z", ".col", ".rom" },
                     TgbdId = 31,
                     TgbdPlatform = "Colecovision",
                     EmuMoviesPlatform = "Coleco_Vision"
@@ -120,7 +120,7 @@
                 {
                     ConsoleType = "Commodore 64",
                     Name = "Commodore64",
-                    Extensions = new[] { ".crt", ".d64", ".g64", ".prg", ".tap", ".t64" },
+                    Extensions = new[] { ".zip", ".7z", ".crt", ".d64", ".g64", ".prg", ".tap", ".t64" },
                     TgbdId = 40,
                     TgbdPlatform = "Commodore 64",
                     EmuMoviesPlatform = "Commodore_64"
@@ -140,7 +140,7 @@
                 {
                     ConsoleType = "Commodore Vic-20",
                     Name = "CommodoreVic20",
-                    Extensions = new[] { ".prg" },
+                    Extensions = new[] { ".zip", ".7z", ".prg" },
                     TgbdId = 4945,
                     TgbdPlatform = "Commodore Vic-20",
                     EmuMoviesPlatform = null
@@ -151,7 +151,7 @@
                 {
                     ConsoleType = "Intellivision",
                     Name = "Intellivision",
-                    Extensions = new[] { ".int", ".rom" },
+                    Extensions = new[] { ".zip", ".7z", ".int", ".rom" },
                     TgbdId = 32,
                     TgbdPlatform = "Intellivision",
                     EmuMoviesPlatform = "Mattel_Intellivision"
@@ -223,7 +223,7 @@
                 {
                     ConsoleType = "TurboGrafx 16",
                     Name = "TurboGrafx16",
-                    Extensions = new[] { ".pce", ".zip" },
+                    Extensions = new[] { ".zip", ".7z", ".pce" },
                     TgbdId = 34,
                     TgbdPlatform = "TurboGrafx 16",
                     EmuMoviesPlatform = "NEC_TurboGrafx_16"
@@ -244,7 +244,7 @@
                 {
                     ConsoleType = "Game Boy",
                     Name = "NintendoGameBoy",
-                    Extensions = new[] { ".gb", ".zip" },
+                    Extensions = new[] { ".zip", ".7z", ".gb" },
                     TgbdId = 4,
                     TgbdPlatform = "Nintendo Game Boy",
                     EmuMoviesPlatform = "Nintendo_Game_Boy"
@@ -254,7 +254,7 @@
                 {
                     ConsoleType = "Game Boy Advance",
                     Name = "NintendoGameBoyAdvance",
-                    Extensions = new[] { ".gba", ".zip" },
+                    Extensions = new[] { ".zip", ".7z", ".gba" },
                     TgbdId = 5,
                     TgbdPlatform = "Nintendo Game Boy Advance",
                     EmuMoviesPlatform = "Nintendo_Game_Boy_Advance"
@@ -264,7 +264,7 @@
                 {
                     ConsoleType = "Game Boy Color",
                     Name = "NintendoGameBoyColor",
-                    Extensions = new[] { ".gbc", ".zip" },
+                    Extensions = new[] { ".zip", ".7z", ".gbc" },
                     TgbdId = 41,
                     TgbdPlatform = "Nintendo Game Boy Color",
                     EmuMoviesPlatform = "Nintendo_Game_Boy_Color"
@@ -274,7 +274,7 @@
                 {
                     ConsoleType = "Gamecube",
                     Name = "NintendoGameCube",
-                    Extensions = new[] { ".iso", ".bin", ".img", ".gcm", ".gcz" },
+                    Extensions = new[] { ".zip", ".7z", ".iso", ".bin", ".img", ".gcm", ".gcz" },
                     TgbdId = 2,
                     TgbdPlatform = "Nintendo GameCube",
                     EmuMoviesPlatform = "Nintendo_GameCube"
@@ -284,7 +284,7 @@
                 {
                     ConsoleType = "Nintendo 64",
                     Name = "Nintendo64",
-                    Extensions = new[] { ".z64", ".v64", ".usa", ".jap", ".pal", ".rom", ".n64", ".zip" },
+                    Extensions = new[] { ".zip", ".7z", ".z64", ".v64", ".usa", ".jap", ".pal", ".rom", ".n64" },
                     TgbdId = 3,
                     TgbdPlatform = "Nintendo 64",
                     EmuMoviesPlatform = "Nintendo_N64"
@@ -294,7 +294,7 @@
                 {
                     ConsoleType = "Nintendo DS",
                     Name = "NintendoDS",
-                    Extensions = new[] { ".nds", ".zip" },
+                    Extensions = new[] { ".zip", ".7z", ".nds" },
                     TgbdId = 8,
                     TgbdPlatform = "Nintendo DS",
                     EmuMoviesPlatform = "Nintendo_DS"
@@ -304,7 +304,7 @@
                 {
                     ConsoleType = "Nintendo",
                     Name = "Nintendo",
-                    Extensions = new[] { ".nes", ".zip" },
+                    Extensions = new[] { ".zip", ".7z", ".nes" },
                     TgbdId = 7,
                     TgbdPlatform = "Nintendo Entertainment System (NES)",
                     EmuMoviesPlatform = "Nintendo_NES"
@@ -314,7 +314,7 @@
                 {
                     ConsoleType = "Super Nintendo",
                     Name = "SuperNintendo",
-                    Extensions = new[] { ".smc", ".zip", ".fam", ".rom", ".sfc", ".fig" },
+                    Extensions = new[] { ".zip", ".7z", ".smc", ".fam", ".rom", ".sfc", ".fig" },
                     TgbdId = 6,
                     TgbdPlatform = "Super Nintendo (SNES)",
                     EmuMoviesPlatform = "Nintendo_SNES"
@@ -324,7 +324,7 @@
                 {
                     ConsoleType = "Virtual Boy",
                     Name = "VirtualBoy",
-                    Extensions = new[] { ".vb" },
+                    Extensions = new[] { ".zip", ".7z", ".vb" },
                     TgbdId = 4918,
                     TgbdPlatform = "Nintendo Virtual Boy",
                     EmuMoviesPlatform = null
@@ -366,7 +366,7 @@
                 {
                     ConsoleType = "Sega 32X",
                     Name = "Sega32X",
-                    Extensions = new[] { ".iso", ".bin", ".img", ".zip", ".32x" },
+                    Extensions = new[] { ".zip", ".7z", ".iso", ".bin", ".img", ".32x" },
                     TgbdId = 33,
                     TgbdPlatform = "Sega 32X",
                     EmuMoviesPlatform = "Sega_Genesis"
@@ -396,7 +396,7 @@
                 {
                     ConsoleType = "Game Gear",
                     Name = "SegaGameGear",
-                    Extensions = new[] { ".gg", ".zip" },
+                    Extensions = new[] { ".zip", ".7z", ".gg" },
                     TgbdId = 20,
                     TgbdPlatform = "Sega Game Gear",
                     EmuMoviesPlatform = "Sega_Game_Gear"
@@ -406,7 +406,7 @@
                 {
                     ConsoleType = "Sega Mega Drive",
                     Name = "SegaMegaDrive",
-                    Extensions = new[] { ".smd", ".zip", ".md" },
+                    Extensions = new[] { ".zip", ".7z", ".smd", ".md" },
                     TgbdId = 36,
                     TgbdPlatform = "Sega Genesis",
                     EmuMoviesPlatform = "Sega_Genesis"
@@ -416,7 +416,7 @@
                 {
                     ConsoleType = "Sega Genesis",
                     Name = "SegaGenesis",
-                    Extensions = new[] { ".smd", ".bin", ".gen", ".zip", ".md" },
+                    Extensions = new[] { ".zip", ".7z", ".smd", ".bin", ".gen", ".md" },
                     TgbdId = 18,
                     TgbdPlatform = "Sega Genesis",
                     EmuMoviesPlatform = "Sega_Genesis"
@@ -426,7 +426,7 @@
                 {
                     ConsoleType = "Sega Master System",
                     Name = "SegaMasterSystem",
-                    Extensions = new[] { ".sms", ".sg", ".sc", ".zip" },
+                    Extensions = new[] { ".zip", ".7z", ".sms", ".sg", ".sc" },
                     TgbdId = 35,
                     TgbdPlatform = "Sega Master System",
                     EmuMoviesPlatform = "Sega_Master_System"
@@ -447,7 +447,7 @@
                 {
                     ConsoleType = "ZX Spectrum",
                     Name = "ZxSpectrum",
-                    Extensions = new[] { ".z80", ".tap", ".tzx" },
+                    Extensions = new[] { ".zip", ".7z", ".z80", ".tap", ".tzx" },
                     TgbdId = 4913,
                     TgbdPlatform = "ZX Spectrum",
                     EmuMoviesPlatform = null
@@ -458,7 +458,7 @@
                 {
                     ConsoleType = "Neo Geo",
                     Name = "NeoGeo",
-                    Extensions = new[] { ".zip", ".iso" },
+                    Extensions = new[] { ".zip", ".7z", ".iso" },
                     TgbdId = 24,
                     TgbdPlatform = "NeoGeo",
                     EmuMoviesPlatform = "SNK_Neo_Geo_AES"
@@ -468,7 +468,7 @@
                 {
                     ConsoleType = "Neo Geo Pocket",
                     Name = "NeoGeoPocket",
-                    Extensions = new[] { ".ngp" },
+                    Extensions = new[] { ".zip", ".7z", ".ngp" },
                     TgbdId = 4922,
                     TgbdPlatform = "Neo Geo Pocket",
                     EmuMoviesPlatform = null
@@ -478,7 +478,7 @@
                 {
                     ConsoleType = "Neo Geo Pocket Color",
                     Name = "NeoGeoPocketColor",
-                    Extensions = new[] { ".ngc" },
+                    Extensions = new[] { ".zip", ".7z", ".ngc" },
                     TgbdId = 4923,
                     TgbdPlatform = "Neo Geo Pocket Color",
                     EmuMoviesPlatform = null

--- a/GameBrowser/Resolvers/ResolverHelper.cs
+++ b/GameBrowser/Resolvers/ResolverHelper.cs
@@ -32,6 +32,8 @@ namespace GameBrowser.Resolvers
                                                         {"Xbox 360", 15},                                                        
                                                         {"Xbox One", 4920},
                                                         {"Neo Geo", 24},
+                                                        {"Neo Geo Pocket", 4922},
+                                                        {"Neo Geo Pocket Color", 4923},
                                                         {"Nintendo 64", 3},
                                                         {"Nintendo DS", 8},
                                                         {"Virtual Boy", 4918},
@@ -143,6 +145,12 @@ namespace GameBrowser.Resolvers
 
                 case "Neo Geo":
                     return "NeoGeo";
+
+                case "Neo Geo Pocket":
+                    return "NeoGeoPocket";
+
+                case "Neo Geo Pocket Color":
+                    return "NeoGeoPocketColor";
 
                 case "Nintendo 64":
                     return "Nintendo64";
@@ -297,6 +305,12 @@ namespace GameBrowser.Resolvers
 
                 case "Neo Geo":
                     return "NeoGeoGame";
+
+                case "Neo Geo Pocket":
+                    return "NeoGeoPocketGame";
+
+                case "Neo Geo Pocket Color":
+                    return "NeoGeoPocketColorGame";
 
                 case "Nintendo 64":
                     return "N64Game";

--- a/GameBrowser/Resolvers/ResolverHelper.cs
+++ b/GameBrowser/Resolvers/ResolverHelper.cs
@@ -23,6 +23,7 @@ namespace GameBrowser.Resolvers
                                                         {"Atari Jaguar", 28},
                                                         {"Atari Jaguar CD", 29},
                                                         {"Atari Lynx", 4924},
+                                                        {"Atari ST", 4937},
                                                         {"Atari XE", 30},
                                                         {"Colecovision", 31},
                                                         {"Commodore 64", 40},
@@ -109,6 +110,9 @@ namespace GameBrowser.Resolvers
 
                 case "Atari 7800":
                     return "Atari7800";
+
+                case "Atari ST":
+                    return "AtariST";
 
                 case "Atari XE":
                     return "AtariXE";
@@ -269,6 +273,9 @@ namespace GameBrowser.Resolvers
 
                 case "Atari 7800":
                     return "Atari7800Game";
+
+                case "Atari ST":
+                    return "AtariSTGame";
 
                 case "Atari XE":
                     return "AtariXeGame";

--- a/GameBrowser/Resolvers/ResolverHelper.cs
+++ b/GameBrowser/Resolvers/ResolverHelper.cs
@@ -22,6 +22,7 @@ namespace GameBrowser.Resolvers
                                                         {"Atari 7800", 27},
                                                         {"Atari Jaguar", 28},
                                                         {"Atari Jaguar CD", 29},
+                                                        {"Atari Lynx", 4924},
                                                         {"Atari XE", 30},
                                                         {"Colecovision", 31},
                                                         {"Commodore 64", 40},
@@ -114,6 +115,9 @@ namespace GameBrowser.Resolvers
 
                 case "Atari Jaguar CD":
                     return "AtariJaguarCD";
+
+                case "Atari Lynx":
+                    return "AtariLynx";
 
                 case "Colecovision":
                     return "Colecovision";
@@ -265,6 +269,9 @@ namespace GameBrowser.Resolvers
 
                 case "Atari Jaguar CD":
                     return "JaguarGame";
+
+                case "Atari Lynx":
+                    return "AtariLynxGame";
 
                 case "Colecovision":
                     return "ColecovisionGame";

--- a/GameBrowser/Resolvers/ResolverHelper.cs
+++ b/GameBrowser/Resolvers/ResolverHelper.cs
@@ -1,75 +1,40 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using MediaBrowser.Model.IO;
 
 namespace GameBrowser.Resolvers
 {
+
     class ResolverHelper
     {
-        public static int? GetTgdbId(string consoleType)
+        private static ILookup<string, GameSystemDefinition> extendedInfoFromConsoleType;
+        private static ILookup<string, GameSystemDefinition> extendedInfoFromGameSystem;
+
+        static ResolverHelper()
         {
-            return TgdbId.ContainsKey(consoleType) ? TgdbId[consoleType] : 0;
+            extendedInfoFromConsoleType = GameSystemDefinition.All.ToLookup(system => system.ConsoleType, StringComparer.OrdinalIgnoreCase);
+            extendedInfoFromGameSystem = GameSystemDefinition.All.ToLookup(system => system.Name, StringComparer.OrdinalIgnoreCase);
         }
 
-        public static Dictionary<string, int> TgdbId = new Dictionary<string, int>
+        public static GameSystemDefinition GetExtendedInfoFromPlatform(string platform)
         {
-                                                        {"3DO", 25},
-                                                        {"Amiga", 4911},
-                                                        {"Arcade", 23},
-                                                        {"Atari 2600", 22},
-                                                        {"Atari 5200", 26},
-                                                        {"Atari 7800", 27},
-                                                        {"Atari Jaguar", 28},
-                                                        {"Atari Jaguar CD", 29},
-                                                        {"Atari Lynx", 4924},
-                                                        {"Atari ST", 4937},
-                                                        {"Atari XE", 30},
-                                                        {"Colecovision", 31},
-                                                        {"Commodore 64", 40},
-                                                        {"DOS", 1},
-                                                        {"Intellivision", 32},
-                                                        {"Xbox", 14},
-                                                        {"Xbox 360", 15},                                                        
-                                                        {"Xbox One", 4920},
-                                                        {"Neo Geo", 24},
-                                                        {"Neo Geo Pocket", 4922},
-                                                        {"Neo Geo Pocket Color", 4923},
-                                                        {"Nintendo 64", 3},
-                                                        {"Nintendo DS", 8},
-                                                        {"Virtual Boy", 4918},
-                                                        {"Nintendo", 7}, 
-                                                        {"Game Boy", 4},
-                                                        {"Game Boy Advance", 5},
-                                                        {"Game Boy Color", 41},
-                                                        {"Gamecube", 2},
-                                                        {"Super Nintendo", 6},
-                                                        {"Nintendo Wii", 9},
-                                                        {"Nintendo Wii U", 38},
-                                                        {"PC", 1},
-                                                        {"Sega 32X", 33},
-                                                        {"Sega CD", 21},
-                                                        {"Dreamcast", 16},
-                                                        {"Game Gear", 20},
-                                                        {"Sega Genesis", 18},
-                                                        {"Sega Master System", 35},
-                                                        {"Sega Mega Drive", 36},
-                                                        {"Sega Saturn", 17},
-                                                        {"Sony Playstation", 10},
-                                                        {"PS2", 11},
-                                                        {"PS3", 12},
-                                                        {"PS4", 4919},
-                                                        {"PSP", 13},
-                                                        {"TurboGrafx 16", 34},
-                                                        {"TurboGrafx CD", 34},
-                                                        {"Windows", 1}
-                                                    };
+            // platform == consoleType
+            return extendedInfoFromConsoleType[platform].FirstOrDefault();
+        }
+        public static GameSystemDefinition GetExtendedInfoFromConsoleType(string consoleType)
+        {
+            return extendedInfoFromConsoleType[consoleType].FirstOrDefault();
+        }
+        public static GameSystemDefinition GetExtendedInfoFromGameSystem(string gameSystem)
+        {
+            return extendedInfoFromGameSystem[gameSystem].FirstOrDefault();
+        }
 
         public static string AttemptGetGamePlatformTypeFromPath(IFileSystem fileSystem, string path)
         {
             var system = Plugin.Instance.Configuration.GameSystems.FirstOrDefault(s => fileSystem.ContainsSubPath(s.Path, path) || string.Equals(s.Path, path, StringComparison.OrdinalIgnoreCase));
 
-            return system != null ? system.ConsoleType : null;
+            return system?.ConsoleType;
         }
 
         public static string GetGameSystemFromPath(IFileSystem fileSystem, string path)
@@ -81,333 +46,7 @@ namespace GameBrowser.Resolvers
                 return null;
             }
 
-            return GetGameSystemFromPlatform(platform);
-        }
-
-        public static string GetGameSystemFromPlatform(string platform)
-        {
-            if (string.IsNullOrEmpty(platform))
-            {
-                throw new ArgumentNullException("platform");
-            }
-
-            switch (platform)
-            {
-                case "3DO":
-                    return "Panasonic3DO";
-
-                case "Amiga":
-                    return "Amiga";
-
-                case "Arcade":
-                    return "Arcade";
-
-                case "Atari 2600":
-                    return "Atari2600";
-
-                case "Atari 5200":
-                    return "Atari5200";
-
-                case "Atari 7800":
-                    return "Atari7800";
-
-                case "Atari ST":
-                    return "AtariST";
-
-                case "Atari XE":
-                    return "AtariXE";
-
-                case "Atari Jaguar":
-                    return "AtariJaguar";
-
-                case "Atari Jaguar CD":
-                    return "AtariJaguarCD";
-
-                case "Atari Lynx":
-                    return "AtariLynx";
-
-                case "Colecovision":
-                    return "Colecovision";
-
-                case "Commodore 64":
-                    return "Commodore64";
-
-                case "Commodore Vic-20":
-                    return "CommodoreVic20";
-
-                case "Intellivision":
-                    return "Intellivision";
-
-                case "Xbox":
-                    return "MicrosoftXBox";
-
-                case "Xbox 360":
-                    return "MicrosoftXBox360";
-
-                case "Xbox One":
-                    return "MicrosoftXBoxOne";
-
-                case "Neo Geo":
-                    return "NeoGeo";
-
-                case "Neo Geo Pocket":
-                    return "NeoGeoPocket";
-
-                case "Neo Geo Pocket Color":
-                    return "NeoGeoPocketColor";
-
-                case "Nintendo 64":
-                    return "Nintendo64";
-
-                case "Nintendo DS":
-                    return "NintendoDS";
-
-                case "Nintendo":
-                    return "Nintendo";
-
-                case "Game Boy":
-                    return "NintendoGameBoy";
-
-                case "Game Boy Advance":
-                    return "NintendoGameBoyAdvance";
-
-                case "Game Boy Color":
-                    return "NintendoGameBoyColor";
-
-                case "Gamecube":
-                    return "NintendoGameCube";
-
-                case "Super Nintendo":
-                    return "SuperNintendo";
-
-                case "Virtual Boy":
-                    return "VirtualBoy";
-
-                case "Nintendo Wii":
-                    return "Wii";
-
-                case "Nintendo Wii U":
-                    return "WiiU";
-
-                case "DOS":
-                    return "DOS";
-
-                case "Windows":
-                    return "Windows";
-
-                case "Sega 32X":
-                    return "Sega32X";
-
-                case "Sega CD":
-                    return "SegaCD";
-
-                case "Dreamcast":
-                    return "SegaDreamcast";
-
-                case "Game Gear":
-                    return "SegaGameGear";
-
-                case "Sega Genesis":
-                    return "SegaGenesis";
-
-                case "Sega Master System":
-                    return "SegaMasterSystem";
-
-                case "Sega Mega Drive":
-                    return "SegaMegaDrive";
-
-                case "Sega Saturn":
-                    return "SegaSaturn";
-
-                case "Sony Playstation":
-                    return "SonyPlaystation";
-
-                case "PS2":
-                    return "SonyPlaystation2";
-
-                case "PS3":
-                    return "SonyPlaystation3";
-
-                case "PS4":
-                    return "SonyPlaystation4";
-
-                case "PSP":
-                    return "SonyPSP";
-
-                case "TurboGrafx 16":
-                    return "TurboGrafx16";
-
-                case "TurboGrafx CD":
-                    return "TurboGrafxCD";
-
-                case "ZX Spectrum":
-                    return "ZxSpectrum";
-
-            }
-            return null;
-        }
-
-        public static string GetDisplayMediaTypeFromPlatform(string platform)
-        {
-            if (string.IsNullOrEmpty(platform))
-            {
-                throw new ArgumentNullException("platform");
-            }
-
-            switch (platform)
-            {
-                case "3DO":
-                    return "Panasonic3doGame";
-
-                case "Amiga":
-                    return "AmigaGame";
-
-                case "Arcade":
-                    return "ArcadeGame";
-
-                case "Atari 2600":
-                    return "Atari2600Game";
-
-                case "Atari 5200":
-                    return "Atari5200Game";
-
-                case "Atari 7800":
-                    return "Atari7800Game";
-
-                case "Atari ST":
-                    return "AtariSTGame";
-
-                case "Atari XE":
-                    return "AtariXeGame";
-
-                case "Atari Jaguar":
-                    return "JaguarGame";
-
-                case "Atari Jaguar CD":
-                    return "JaguarGame";
-
-                case "Atari Lynx":
-                    return "AtariLynxGame";
-
-                case "Colecovision":
-                    return "ColecovisionGame";
-
-                case "Commodore 64":
-                    return "C64Game";
-
-                case "Commodore Vic-20":
-                    return "Vic20Game";
-
-                case "Intellivision":
-                    return "IntellivisionGame";
-
-                case "Xbox":
-                    return "XboxGame";
-
-                case "Xbox 360":
-                    return "Xbox360Game";
-
-                case "Xbox One":
-                    return "XboxOneGame";
-
-                case "Neo Geo":
-                    return "NeoGeoGame";
-
-                case "Neo Geo Pocket":
-                    return "NeoGeoPocketGame";
-
-                case "Neo Geo Pocket Color":
-                    return "NeoGeoPocketColorGame";
-
-                case "Nintendo 64":
-                    return "N64Game";
-
-                case "Nintendo DS":
-                    return "NesGame";
-
-                case "Nintendo":
-                    return "NesGame";
-
-                case "Game Boy":
-                    return "GameBoyGame";
-
-                case "Game Boy Advance":
-                    return "GameBoyAdvanceGame";
-
-                case "Game Boy Color":
-                    return "GameBoyColorGame";
-
-                case "Gamecube":
-                    return "GameCubeGame";
-
-                case "Super Nintendo":
-                    return "SnesGame";
-
-                case "Virtual Boy":
-                    return "NesGame";
-
-                case "Nintendo Wii":
-                    return "NesGame";
-
-                case "Nintendo Wii U":
-                    return "WiiUGame";
-
-                case "DOS":
-                    return "DosGame";
-
-                case "Windows":
-                    return "WindowsGame";
-
-                case "Sega 32X":
-                    return "GenesisGame";
-
-                case "Sega CD":
-                    return "GenesisGame";
-
-                case "Dreamcast":
-                    return "GenesisGame";
-
-                case "Game Gear":
-                    return "GenesisGame";
-
-                case "Sega Genesis":
-                    return "GenesisGame";
-
-                case "Sega Master System":
-                    return "GenesisGame";
-
-                case "Sega Mega Drive":
-                    return "GenesisGame";
-
-                case "Sega Saturn":
-                    return "GenesisGame";
-
-                case "Sony Playstation":
-                    return "PsOneGame";
-
-                case "PS2":
-                    return "Ps2Game";
-
-                case "PS3":
-                    return "Ps3Game";
-
-                case "PS4":
-                    return "Ps4Game";
-
-                case "PSP":
-                    return "PlayStationPortableGame";
-
-                case "TurboGrafx 16":
-                    return "TurboGrafx16Game";
-
-                case "TurboGrafx CD":
-                    return "TurboGrafx16Game";
-
-                case "ZX Spectrum":
-                    return "ZXSpectrumGame";
-
-            }
-            return null;
+            return ResolverHelper.GetExtendedInfoFromPlatform(platform)?.Name;
         }
     }
 }

--- a/GameBrowser/Resolvers/ResolverHelper.cs
+++ b/GameBrowser/Resolvers/ResolverHelper.cs
@@ -34,6 +34,7 @@ namespace GameBrowser.Resolvers
                                                         {"Neo Geo", 24},
                                                         {"Nintendo 64", 3},
                                                         {"Nintendo DS", 8},
+                                                        {"Virtual Boy", 4918},
                                                         {"Nintendo", 7}, 
                                                         {"Game Boy", 4},
                                                         {"Game Boy Advance", 5},


### PR DESCRIPTION
The main problem is that the 'switch cases' are not always coherent in the library.  

There is a first conversion from "Emby Platform" to "Emby GameSystem". Then, for each provider, there is another switch case to convert an "Emby GameSystem" to a "game provider specific platform" but the switch case use "Emby Platform" string instead of "Emby GameSystem".

So the end result is: 

1. Emby Platform: "Nintendo 64" => Emby GameSystem: "Nintendo64" (in method ResolverHelper.GetGameSystemFromPlatform)
2. Emby GameSystem: "Nintendo64" => **Tgbd Platform: null**, because the switch case is looking for "Nintendo 64" with a space (in method GameBrowser.Providers.GamesDb.GetTgdbPlatformFromGameSystem)
3. The search with the provider API is done without a Platform and often return an ID from another platform
`Info HttpClient: GET http://thegamesdb.net/api/GetGamesList.php?name=5200+Menu+&platform=`
4. The metadata, images, etc are all taken from the wrong game system.

 Before Fix:
![screenshot 1526787966](https://user-images.githubusercontent.com/7834067/40588902-a89554ce-61b2-11e8-8417-51322b110d88.png)

After Fix:
![screenshot 1527078404](https://user-images.githubusercontent.com/7834067/40588910-b3efc228-61b2-11e8-8a93-02376f8bb631.png)

After fixing the issue, I updated a few others things:

- Added a few GameSystem (Atari Lynx, Atari ST, Neo Geo Pocket, Neo Geo Pocket Color).
- Added some missing TgbdId for some system (VirtualBoy).
- Added image types for EmuMovies provider (Banner, BoxRear, Screenshot, etc).
- And I ended up refactoring the code to remove the multiple switch case. Instead, I created a single "GameSystemDefinition" instance for each game system, which should reduce the risk of error and simplify the addition of more GameSystem in the future.
- Changed so that the plugin never search for a TgbdId if tgbdGameSystem is null.

I'm not sure of the best way to fix 'corrupted' games in an existing library because the ID is invalid and is never modified on a rescan. 
What I ended up doing is:
1. Rename "games" to "games-old" folder. 
2. Scan Library. I saw a bunch of metadata deletion in library.
	2018-05-22 20:58:21.329 Debug App: Deleting path C:\Users\cwarr\AppData\Roaming\Emby-Server\metadata\library\21\21bd78c11f26a1542ebb5219d8820b49
	2018-05-22 20:58:21.337 Debug App: Deleting path C:\Users\cwarr\AppData\Roaming\Emby-Server\metadata\library\a0\a04f6756481c010d5ec00bd8e6dda3d6
	2018-05-22 20:58:21.346 Debug App: Deleting path C:\Users\cwarr\AppData\Roaming\Emby-Server\metadata\library\8d\8d2e47f8655d091baa196e9fb99609df
3. Delete .xml file and images in game folders.
4. Rename "games-old" to "games.
5. Scan Library. I saw the plugin call "GetGamesList" with the right platform and the correct images were downloaded as well.
	2018-05-22 21:03:28.761 Debug App: Running GamesDbGameProvider for C:\Partage\Medias\Emulation\Games\Atari - 5200\5200 Menu (USA) (Proto)\5200 Menu (USA) (Proto).a52
	2018-05-22 21:03:28.761 Info HttpClient: GET http://thegamesdb.net/api/GetGamesList.php?name=5200+Menu+&platform=Atari 5200
