### PR TITLE
Add .m3u support for multi-disc consoles (PS1, PS2, Saturn, DC, GC)

### DIFF
--- a/GameBrowser/Resolvers/GameResolver.cs
+++ b/GameBrowser/Resolvers/GameResolver.cs
@@ -180,7 +180,7 @@ namespace GameBrowser.Resolvers
                     return new[] { ".nds", ".zip" };
 
                 case "Nintendo 3DS":
-                    return new[] { ".3ds", ".cia" };
+                    return new[] { ".3ds", ".3dsx", ".cia", ".cxi" ".cci", ".zcci", ".zcxi", ".z3dsx" };
 
                 case "Nintendo":
                     return new[] { ".nes", ".zip" };


### PR DESCRIPTION
Added .m3u extension support to the GameResolver for disc-based platforms. This allows modern emulators to handle multi-disc games as a single library entry. Platforms updated: Sony PlayStation 1 & 2, Sega Saturn, Sega CD, Dreamcast, and Nintendo GameCube.